### PR TITLE
feat: Add Host Mac address and Host IpAddress to AddNode gRPC call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "librms"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "NVIDIA Rack Manager Service client"
 authors = [ "NVIDIA Engineering <dcss-forge-rms@exchange.nvidia.com>" ]
 repository = "https://github.com/NVIDIA/nv-rms-client.git"
 license = "Apache-2.0"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 
 [dependencies]

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -132,6 +132,8 @@ message NewNodeInfo {
   optional NodeType type = 7;     // Type/category of the node
   string rack_id = 8;             // Identifier of the rack containing this node
   string vault_path = 9;          // Vault path to the creds of the Node
+  repeated string host_mac_addresses = 10;   // Vector of MAC addresses of the node's Host interfaces
+  repeated string host_ip_addresses = 11;   // Vector of IP addresses of the node's Host interfaces
 }
 
 /*
@@ -144,6 +146,7 @@ message NodeUpdateInfo {
   optional string username = 3;    // New BMC username for testing only
   optional string password = 4;    // New BMC password for testing only
   optional string vault_path = 5;  // New Vault path for credential lookup (e.g., "switch_nvos/{mac_address}/admin")
+  repeated string host_ip_addresses = 6;   // Vector of IP addresses of the node's Host interfaces
 }
 
 // NodeInventoryInfo represents complete inventory information for a node.
@@ -158,6 +161,8 @@ message NodeInventoryInfo {
   string mac_address = 8;                   // MAC address of the node's BMC interface
   string rack_id = 9;                       // Identifier of the rack containing this node
   string vault_path = 10;                   // Vault path to the creds of the Node
+  repeated string host_mac_addresses = 11;   // Vector of MAC addresses of the node's Host interfaces
+  repeated string host_ip_addresses = 12;   // Vector of IP addresses of the node's Host interfaces
 }
 
 // DeviceInventoryInfo represents inventory information for a device/component within a node.


### PR DESCRIPTION
Protobuf changes to AddNode to support host mac and ipaddess to RMS