### PR TITLE
feat: switch nvos password rotation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -405,6 +405,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "rack_manager.GetSwitchSystemImageJobStatusResponse",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
+        .type_attribute(
+            "rack_manager.NodePasswordUpdateResult",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "rack_manager.UpdateSwitchSystemPasswordRequest",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "rack_manager.UpdateSwitchSystemPasswordResponse",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
         .include_file("prost_common.rs")
         .build_server(false)
         .build_client(true)

--- a/build.rs
+++ b/build.rs
@@ -406,10 +406,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
         .type_attribute(
-            "rack_manager.NodePasswordUpdateResult",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
             "rack_manager.UpdateSwitchSystemPasswordRequest",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1072,11 +1072,6 @@ message UpdateSwitchSystemPasswordRequest {
 // UpdateSwitchSystemPasswordResponse reports the per-node results of a synchronous password update.
 message UpdateSwitchSystemPasswordResponse {
   Metadata metadata = 1;
-  ReturnCode status = 2;                                    // SUCCESS if all nodes succeeded, FAILURE if any failed
-  string message = 3;                                       // Human-readable summary message
-  int32 total_nodes = 4;                                    // Total number of switch devices targeted
-  int32 successful_updates = 5;                             // Number of switch devices successfully updated
-  int32 failed_updates = 6;                                 // Number of switch devices that failed to update
   repeated NodePasswordUpdateResult node_results = 7;       // Individual result per switch node
 }
 

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -248,13 +248,6 @@ message NodeUpdateResult {
   string error_message = 3;            // Human-readable error message
 }
 
-// NodePasswordUpdateResult reports the outcome of a password update on a specific switch node.
-message NodePasswordUpdateResult {
-  string node_id = 1;        // Switch node that was targeted
-  ReturnCode status = 2;     // SUCCESS or FAILURE for this node
-  string error_message = 3;  // Human-readable error detail if failed
-}
-
 /*******************************************************************************
  * SERVICE DEFINITION
  *
@@ -1072,7 +1065,7 @@ message UpdateSwitchSystemPasswordRequest {
 // UpdateSwitchSystemPasswordResponse reports the per-node results of a synchronous password update.
 message UpdateSwitchSystemPasswordResponse {
   Metadata metadata = 1;
-  repeated NodePasswordUpdateResult node_results = 7;       // Individual result per switch node
+  repeated NodeUpdateResult node_results = 7;       // Individual result per switch node
 }
 
 /*******************************************************************************

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -248,6 +248,13 @@ message NodeUpdateResult {
   string error_message = 3;            // Human-readable error message
 }
 
+// NodePasswordUpdateResult reports the outcome of a password update on a specific switch node.
+message NodePasswordUpdateResult {
+  string node_id = 1;        // Switch node that was targeted
+  ReturnCode status = 2;     // SUCCESS or FAILURE for this node
+  string error_message = 3;  // Human-readable error detail if failed
+}
+
 /*******************************************************************************
  * SERVICE DEFINITION
  *
@@ -468,7 +475,14 @@ service RackManager {
    * system image update job.
    */
   rpc GetSwitchSystemImageJobStatus(GetSwitchSystemImageJobStatusRequest) returns (GetSwitchSystemImageJobStatusResponse) {}
-  
+
+  /*
+   * UpdateSwitchSystemPassword updates the OS-level password for a specific user
+   * on a caller-supplied list of switch devices. Credentials are resolved from
+   * the node's stored inventory data.
+   */
+  rpc UpdateSwitchSystemPassword(UpdateSwitchSystemPasswordRequest) returns (UpdateSwitchSystemPasswordResponse) {}
+
   /*---------------------------------------------------------------------------
    * Utility RPCs
    *-------------------------------------------------------------------------*/
@@ -1041,6 +1055,29 @@ message PollJobStatusResponse {
   string state = 3;        // State of the job (active,pending,running)   
   string result_json = 4; // JSON object containing configuration result
   string error_message = 5; // Error details if configuration failed
+}
+
+/*******************************************************************************
+ * SWITCH PASSWORD CONTROL MESSAGES
+ ******************************************************************************/
+
+// UpdateSwitchSystemPasswordRequest updates the OS-level password for a user on a set of switch devices.
+message UpdateSwitchSystemPasswordRequest {
+  Metadata metadata = 1;
+  NodeSet nodes = 2;       // Switch devices to update
+  string username = 3;     // Target OS username whose password will be changed (mandatory)
+  string password = 4;     // New password to set for the user (mandatory)
+}
+
+// UpdateSwitchSystemPasswordResponse reports the per-node results of a synchronous password update.
+message UpdateSwitchSystemPasswordResponse {
+  Metadata metadata = 1;
+  ReturnCode status = 2;                                    // SUCCESS if all nodes succeeded, FAILURE if any failed
+  string message = 3;                                       // Human-readable summary message
+  int32 total_nodes = 4;                                    // Total number of switch devices targeted
+  int32 successful_updates = 5;                             // Number of switch devices successfully updated
+  int32 failed_updates = 6;                                 // Number of switch devices that failed to update
+  repeated NodePasswordUpdateResult node_results = 7;       // Individual result per switch node
 }
 
 /*******************************************************************************

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,10 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
     ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError>;
+    async fn update_switch_system_password(
+        &self,
+        cmd: rms::UpdateSwitchSystemPasswordRequest,
+    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>;
 }
 
 #[async_trait::async_trait]
@@ -504,6 +508,15 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError> {
         self.client
             .get_firmware_job_status(cmd)
+            .await
+            .map_err(RackManagerError::from)
+    }
+    async fn update_switch_system_password(
+        &self,
+        cmd: rms::UpdateSwitchSystemPasswordRequest,
+    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
+        self.client
+            .update_switch_system_password(cmd)
             .await
             .map_err(RackManagerError::from)
     }


### PR DESCRIPTION
### What this MR does:
proto support for nvos password rotation

### Why this change is necessary:
- standard switch state machine flow
- support operator flow to rotate password

### What is the change:
- new proto structue

### How to test this change:
NA

### Relevant issues:
https://jirasw.nvidia.com/browse/RCKMANAGER-503

