### PR TITLE
feat: switch attestation tpm measurements

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -413,6 +413,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "rack_manager.UpdateSwitchSystemPasswordResponse",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
+        .type_attribute(
+            "rack_manager.Result",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "rack_manager.SwitchAttestationResult",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "rack_manager.GetSwitchAttestationRequest",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
+        .type_attribute(
+            "rack_manager.GetSwitchAttestationResponse",
+            "#[derive(serde::Deserialize, serde::Serialize)]",
+        )
         .include_file("prost_common.rs")
         .build_server(false)
         .build_client(true)

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -476,6 +476,12 @@ service RackManager {
    */
   rpc UpdateSwitchSystemPassword(UpdateSwitchSystemPasswordRequest) returns (UpdateSwitchSystemPasswordResponse) {}
 
+  /*
+   * GetSwitchAttestation generates and copies TPM on a caller-supplied list of
+   * switch devices. Credentials to access the switches are passed from the client.
+   */
+  rpc GetSwitchAttestation(GetSwitchAttestationRequest) returns (GetSwitchAttestationResponse) {}
+
   /*---------------------------------------------------------------------------
    * Utility RPCs
    *-------------------------------------------------------------------------*/
@@ -1066,6 +1072,31 @@ message UpdateSwitchSystemPasswordRequest {
 message UpdateSwitchSystemPasswordResponse {
   Metadata metadata = 1;
   repeated NodeUpdateResult node_results = 7;       // Individual result per switch node
+}
+
+//Result per Switch Tray.
+message Result {
+  string node_id = 1;
+  ReturnCode status = 2;
+  string error_message = 3;
+}
+
+//SwitchAttestationResult per switch Tray.
+message SwitchAttestationResult {
+  Result result = 1;
+  string artifact_path = 2; // Shared path to accesss attestation measurements.
+}
+
+//GetSwitchAttestationRequest generates and gets the Switch TPM quotes.json on a set of switch devices.
+message GetSwitchAttestationRequest {
+  Metadata metadata = 1;
+  NodeSet nodes = 2; // Switch devices to get attestation measurements
+}
+
+//GetSwitchAttestationResponse reports the per-node results of a synchronous Switch Attestation measurements.
+message GetSwitchAttestationResponse {
+  Metadata metadata = 1;
+  repeated SwitchAttestationResult results = 2; // Generated attestation measurements results
 }
 
 /*******************************************************************************

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ use tonic::Status;
 use crate::client::{RackManagerClientT, RetryConfig, RmsApiConfig, RmsTlsClient};
 use crate::client_config::RmsClientConfig;
 use crate::protos::rack_manager as rms;
-use crate::protos::rack_manager::{UpgradeFirmwareOnSwitchCommand, UpgradeFirmwareOnSwitchResponse};
+use crate::protos::rack_manager::{
+    UpgradeFirmwareOnSwitchCommand, UpgradeFirmwareOnSwitchResponse,
+};
 use crate::protos::rack_manager_client::RackManagerApiClient;
 pub mod client;
 pub mod client_config;
@@ -252,6 +254,10 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::UpdateSwitchSystemPasswordRequest,
     ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>;
+    async fn get_switch_attestation(
+        &self,
+        cmd: rms::GetSwitchAttestationRequest,
+    ) -> Result<rms::GetSwitchAttestationResponse, RackManagerError>;
 }
 
 #[async_trait::async_trait]
@@ -517,6 +523,15 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
         self.client
             .update_switch_system_password(cmd)
+            .await
+            .map_err(RackManagerError::from)
+    }
+    async fn get_switch_attestation(
+        &self,
+        cmd: rms::GetSwitchAttestationRequest,
+    ) -> Result<rms::GetSwitchAttestationResponse, RackManagerError> {
+        self.client
+            .get_switch_attestation(cmd)
             .await
             .map_err(RackManagerError::from)
     }


### PR DESCRIPTION
### What this PR does:
-  proto changes to support tpm generation on per switch


### Why this change is necessary:
- Security ask for attestation of the switch TPM measurements 
- pre-requisite to schedule workload by csp.

### What is the change:
- part of grpc api switch_security_handlers.rs 

### How to test this change:
- Unit tests 
- Refer Attachment 

### Relevant issues:
- https://jirasw.nvidia.com/browse/RCKMANAGER-741

### Reviewer Checklist:
- [ ] Code is well-documented
- [ ] Tests are adequate
- [ ] Follows coding standards
- [ ] Functionality works as expected
