### PR TITLE
Inventoryless rack power and get power state APIs

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -48,6 +48,13 @@ enum RackPowerOperation {
   RACK_POWER_CYCLE = 2;  // Power cycle all nodes in the rack
 }
 
+// PowerState represents the current power state of a node.
+enum PowerState {
+  POWER_STATE_UNKNOWN = 0;  // Power state is unknown or could not be determined
+  POWER_STATE_ON      = 1;  // Node is powered on
+  POWER_STATE_OFF     = 2;  // Node is powered off
+}
+
 // ReturnCode indicates the overall success or failure of an RPC operation.
 enum ReturnCode {
   SUCCESS = 0;  // Operation completed successfully
@@ -261,6 +268,15 @@ message NodeResult {
   string error_message = 3;  // Human-readable error message for failures
 }
 
+// NodePowerStateResult reports the current power state for a specific node.
+message NodePowerStateResult {
+  string node_id = 1;        // Node that was queried
+  string rack_id = 2;        // Rack containing the node
+  ReturnCode status = 3;     // SUCCESS if this node completed, FAILURE otherwise
+  PowerState pstate = 4;     // Current power state
+  string error_message = 5;  // Human-readable error message for failures
+}
+
 // NodeBatchResponse reports the common result shape for multi-node RPCs.
 message NodeBatchResponse {
   Metadata metadata = 1;
@@ -298,6 +314,24 @@ service RackManager {
    * without requiring them to be registered in RMS inventory.
    */
   rpc SetPowerStateByDeviceList(SetPowerStateByDeviceListRequest) returns (SetPowerStateByDeviceListResponse) {}
+
+  /*
+   * GetPowerStateByDeviceList retrieves power state for caller-supplied devices
+   * without requiring them to be registered in RMS inventory.
+   */
+  rpc GetPowerStateByDeviceList(GetPowerStateByDeviceListRequest) returns (GetPowerStateByDeviceListResponse) {}
+
+  /*
+   * PowerOnRackByDeviceList powers on a rack using caller-supplied devices
+   * without requiring them to be registered in RMS inventory.
+   */
+  rpc PowerOnRackByDeviceList(RackPowerByDeviceListRequest) returns (RackPowerByDeviceListResponse) {}
+
+  /*
+   * PowerOffRackByDeviceList powers off a rack using caller-supplied devices
+   * without requiring them to be registered in RMS inventory.
+   */
+  rpc PowerOffRackByDeviceList(RackPowerByDeviceListRequest) returns (RackPowerByDeviceListResponse) {}
   
   /*
    * GetPowerState retrieves the current power state of a node.
@@ -627,6 +661,30 @@ message SetPowerStateByDeviceListRequest {
 
 // SetPowerStateByDeviceListResponse reports per-device power operation results.
 message SetPowerStateByDeviceListResponse {
+  NodeBatchResponse response = 1;
+}
+
+// GetPowerStateByDeviceListRequest queries power state for unregistered devices.
+message GetPowerStateByDeviceListRequest {
+  Metadata metadata = 1;
+  NodeSet nodes = 2;  // Caller-supplied device connection details
+}
+
+// GetPowerStateByDeviceListResponse reports per-device power state results.
+message GetPowerStateByDeviceListResponse {
+  NodeBatchResponse response = 1;
+  repeated NodePowerStateResult node_power_states = 2;
+}
+
+// RackPowerByDeviceListRequest controls rack power for unregistered devices.
+message RackPowerByDeviceListRequest {
+  Metadata metadata = 1;
+  string rack_id = 2;  // Target rack identifier
+  NodeSet nodes = 3;   // Caller-supplied device connection details
+}
+
+// RackPowerByDeviceListResponse reports per-device rack power operation results.
+message RackPowerByDeviceListResponse {
   NodeBatchResponse response = 1;
 }
 

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -324,12 +324,14 @@ service RackManager {
   /*
    * PowerOnRackByDeviceList powers on a rack using caller-supplied devices
    * without requiring them to be registered in RMS inventory.
+   * Power shelves are not supported by this API at this time.
    */
   rpc PowerOnRackByDeviceList(RackPowerByDeviceListRequest) returns (RackPowerByDeviceListResponse) {}
 
   /*
    * PowerOffRackByDeviceList powers off a rack using caller-supplied devices
    * without requiring them to be registered in RMS inventory.
+   * Power shelves are not supported by this API at this time.
    */
   rpc PowerOffRackByDeviceList(RackPowerByDeviceListRequest) returns (RackPowerByDeviceListResponse) {}
   
@@ -343,6 +345,7 @@ service RackManager {
    * SequenceRackPower controls the power state of all nodes in a rack.
    * Operations follow the configured power-on order for sequenced boot.
    * Requires a valid power-on order to be set before use.
+   * Power shelves are not supported by this API at this time.
    */
   rpc SequenceRackPower(SequenceRackPowerRequest) returns (SequenceRackPowerResponse) {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,18 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetPowerStateByDeviceListRequest,
     ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>;
+    async fn get_power_state_by_device_list(
+        &self,
+        cmd: rms::GetPowerStateByDeviceListRequest,
+    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>;
+    async fn power_on_rack_by_device_list(
+        &self,
+        cmd: rms::RackPowerByDeviceListRequest,
+    ) -> Result<rms::RackPowerByDeviceListResponse, RackManagerError>;
+    async fn power_off_rack_by_device_list(
+        &self,
+        cmd: rms::RackPowerByDeviceListRequest,
+    ) -> Result<rms::RackPowerByDeviceListResponse, RackManagerError>;
     async fn get_power_state(
         &self,
         cmd: rms::GetPowerStateRequest,
@@ -357,6 +369,24 @@ impl RmsApi for RackManagerApi {
         cmd: rms::SetPowerStateByDeviceListRequest,
     ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
         Ok(self.client.set_power_state_by_device_list(cmd).await?)
+    }
+    async fn get_power_state_by_device_list(
+        &self,
+        cmd: rms::GetPowerStateByDeviceListRequest,
+    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
+        Ok(self.client.get_power_state_by_device_list(cmd).await?)
+    }
+    async fn power_on_rack_by_device_list(
+        &self,
+        cmd: rms::RackPowerByDeviceListRequest,
+    ) -> Result<rms::RackPowerByDeviceListResponse, RackManagerError> {
+        Ok(self.client.power_on_rack_by_device_list(cmd).await?)
+    }
+    async fn power_off_rack_by_device_list(
+        &self,
+        cmd: rms::RackPowerByDeviceListRequest,
+    ) -> Result<rms::RackPowerByDeviceListResponse, RackManagerError> {
+        Ok(self.client.power_off_rack_by_device_list(cmd).await?)
     }
     async fn get_power_state(
         &self,


### PR DESCRIPTION
adds 3 apis:

GetPowerStateByDeviceList
PowerOnRackByDeviceList
PowerOffRackByDeviceList

Rack Power on / off APIs will not support powershelves initially.