### PR TITLE
feat: add powershelf power state ap

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -304,6 +304,13 @@ service RackManager {
    * Returns the current state (ON, OFF, or UNKNOWN).
    */
   rpc GetPowerState(GetPowerStateRequest) returns (GetPowerStateResponse) {}
+
+  /*
+   * GetPowerStateByDeviceList retrieves the current power state for caller-
+   * supplied devices without requiring them to be registered in RMS inventory.
+   * Returns per-device power state along with batch status.
+   */
+  rpc GetPowerStateByDeviceList(GetPowerStateByDeviceListRequest) returns (GetPowerStateByDeviceListResponse) {}
   
   /*
    * SequenceRackPower controls the power state of all nodes in a rack.
@@ -644,6 +651,24 @@ message GetPowerStateResponse {
   string node_id = 3;      // Node identifier (echoed from request)
   string pstate = 4;       // Current power state: "ON", "OFF", or "UNKNOWN"
   string rack_id = 5;      // Rack identifier (echoed from request)
+}
+
+// NodePowerState pairs a node identifier with its current power state.
+message NodePowerState {
+  string node_id = 1;  // Node identifier (echoed from request)
+  string pstate = 2;   // Current power state: "ON", "OFF", or "UNKNOWN"
+}
+
+// GetPowerStateByDeviceListRequest queries power state for unregistered devices.
+message GetPowerStateByDeviceListRequest {
+  Metadata metadata = 1;
+  NodeSet nodes = 2;  // Caller-supplied device connection details
+}
+
+// GetPowerStateByDeviceListResponse reports per-device power state results.
+message GetPowerStateByDeviceListResponse {
+  NodeBatchResponse response = 1;
+  repeated NodePowerState node_power_states = 2;  // Power state for each successfully queried device
 }
 
 // RackPowerRequest controls power for all nodes in a rack.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,10 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetPowerStateRequest,
     ) -> Result<rms::GetPowerStateResponse, RackManagerError>;
+    async fn get_power_state_by_device_list(
+        &self,
+        cmd: rms::GetPowerStateByDeviceListRequest,
+    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>;
     async fn sequence_rack_power(
         &self,
         cmd: rms::SequenceRackPowerRequest,
@@ -363,6 +367,12 @@ impl RmsApi for RackManagerApi {
         cmd: rms::GetPowerStateRequest,
     ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
         Ok(self.client.get_power_state(cmd).await?)
+    }
+    async fn get_power_state_by_device_list(
+        &self,
+        cmd: rms::GetPowerStateByDeviceListRequest,
+    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
+        Ok(self.client.get_power_state_by_device_list(cmd).await?)
     }
     async fn sequence_rack_power(
         &self,


### PR DESCRIPTION
GetPowerStateByDeviceList retrieves the current power state for caller-
supplied devices without requiring them to be registered in RMS inventory.
Returns per-device power state along with batch status.
