### PR TITLE
refactor(api)!: clean up and align rack manager proto with gRPC conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "librms"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "NVIDIA Rack Manager Service client"
 authors = [ "NVIDIA Engineering <dcss-forge-rms@exchange.nvidia.com>" ]
 repository = "https://github.com/NVIDIA/nv-rms-client.git"
 license = "Apache-2.0"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ".rack_manager",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
+        // prost_types::Timestamp does not implement serde, so each timestamp field
+        // needs the crate adapter while the rest of the package can use type_attribute.
         .field_attribute(
             "rack_manager.FirmwareObject.created",
             "#[serde(default, with = \"crate::timestamp_serde\")]",
@@ -41,6 +43,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .field_attribute(
             "rack_manager.FirmwareObjectHistoryRecord.applied_at",
+            "#[serde(default, with = \"crate::timestamp_serde\")]",
+        )
+        .field_attribute(
+            "rack_manager.GetFirmwareJobStatusResponse.created_at",
+            "#[serde(default, with = \"crate::timestamp_serde\")]",
+        )
+        .field_attribute(
+            "rack_manager.GetFirmwareJobStatusResponse.updated_at",
+            "#[serde(default, with = \"crate::timestamp_serde\")]",
+        )
+        .field_attribute(
+            "rack_manager.GetSwitchSystemImageJobStatusResponse.created_at",
+            "#[serde(default, with = \"crate::timestamp_serde\")]",
+        )
+        .field_attribute(
+            "rack_manager.GetSwitchSystemImageJobStatusResponse.updated_at",
             "#[serde(default, with = \"crate::timestamp_serde\")]",
         )
         .include_file("prost_common.rs")

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -140,18 +140,12 @@ message NetworkInterface {
   string mac_address = 2; // Text MAC address
 }
 
-// BMC connection info and credentials for authenticating with the node's BMC (Redfish API).
-message BmcEndpoint {
-  NetworkInterface interface = 1;  // BMC network interface (single NIC)
-  uint32 port = 2;                 // Port number for BMC communication (default: 443, max: 65535)
+// Endpoint describes one network endpoint and its credentials.
+message Endpoint {
+  NetworkInterface interface = 1;  // Network interface used to reach this endpoint
+  uint32 port = 2;                 // Port number for endpoint communication (max: 65535)
   Credentials credentials = 3;
-}
-
-// Host connection info and credentials for authenticating with the node's host/switch OS (e.g., SSH, SWITCH API).
-message HostEndpoint {
-  repeated NetworkInterface interfaces = 1;  // Host NICs (multiple supported)
-  uint32 port = 2;                           // Port number for host communication (max: 65535)
-  Credentials credentials = 3;
+  bool dangerously_accept_invalid_certs = 4; // If true, TLS certificate validation is disabled for this endpoint; unset/false keeps normal validation
 }
 
 /*******************************************************************************
@@ -163,8 +157,8 @@ message NodeInfo {
   string node_id = 1;             // Unique identifier for the node within the rack
   string rack_id = 2;             // Identifier of the rack containing this node
   optional NodeType type = 3;     // Type/category of the node
-  optional BmcEndpoint bmc_endpoint = 4;     // BMC connection info and credentials
-  optional HostEndpoint host_endpoint = 5;   // Host connection info and credentials
+  optional Endpoint bmc_endpoint = 4;  // BMC connection info and credentials
+  optional Endpoint host_endpoint = 5; // Host connection info and credentials
 }
 
 // NodeSet represents a collection of nodes, reusable wherever a node list is needed.
@@ -177,8 +171,8 @@ message NodeSet {
  * Only specified fields will be updated; unset fields remain unchanged.
  */
 message NodeUpdateInfo {
-  optional BmcEndpoint bmc_endpoint = 1;    // New BMC connection info and credentials
-  optional HostEndpoint host_endpoint = 2;   // New host connection info and credentials
+  optional Endpoint bmc_endpoint = 1;  // New BMC connection info and credentials
+  optional Endpoint host_endpoint = 2; // New host connection info and credentials
 }
 
 // NodeInventoryInfo represents complete inventory information for a node.
@@ -189,7 +183,7 @@ message NodeInventoryInfo {
   string ip_address = 4;                    // IP address of the node's BMC
   uint32 port = 5;                          // Port number for BMC communication
   NodeType type = 6;                        // Type/category of the node
-  repeated DeviceInventoryInfo components = 7; // List of components within the node
+  repeated ComponentInventoryInfo components = 7; // List of components within the node
   string mac_address = 8;                   // MAC address of the node's BMC interface
   string rack_id = 9;                       // Identifier of the rack containing this node
   repeated string host_mac_addresses = 10;  // Vector of MAC addresses of the node's Host interfaces
@@ -204,16 +198,16 @@ message NodeDeviceInfo {
   optional uint32 tray_index = 4;  // Optional tray index when available
 }
 
-// DeviceInventoryInfo represents inventory information for a device/component within a node.
-message DeviceInventoryInfo {
-  string device_id = 1;       // Unique identifier for the device within the node
+// ComponentInventoryInfo represents inventory information for a component within a node.
+message ComponentInventoryInfo {
+  string component_id = 1;    // Unique identifier for the component within the node
   string health = 2;          // Health status
   string state = 3;           // Operational state (e.g., "Enabled", "Disabled")
-  string model = 4;           // Model name/number of the device
-  string serial_number = 5;   // Serial number of the device
-  string description = 6;     // Human-readable description of the device
+  string model = 4;           // Model name/number of the component
+  string serial_number = 5;   // Serial number of the component
+  string description = 6;     // Human-readable description of the component
   string hardware_type = 7;   // Type of hardware (e.g., "GPU", "NIC", "Storage")
-  int32 type = 8;             // Numeric device type identifier
+  int32 type = 8;             // Numeric component type identifier
 }
 
 // FirmwareInventoryInfo represents firmware information for a component.
@@ -246,30 +240,31 @@ message NodeFirmwareInventory {
 
 // OperationResponse reports the common result shape for simple RPCs.
 message OperationResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;  // RETURN_CODE_SUCCESS if operation completed, RETURN_CODE_FAILURE otherwise
   string message = 3;     // Human-readable status or error message
 }
 
-// NodeResult reports the outcome of an operation on a specific node.
-message NodeResult {
+// NodeOperationResult reports the outcome of an operation on a specific node.
+message NodeOperationResult {
   string node_id = 1;        // Node that was targeted
   ReturnCode status = 2;     // RETURN_CODE_SUCCESS if this node completed, RETURN_CODE_FAILURE otherwise
   string error_message = 3;  // Human-readable error message for failures
 }
 
+// NodeOperationStats reports aggregate node counts for batch-like RPCs.
+message NodeOperationStats {
+  uint32 total_nodes = 1;      // Total number of nodes targeted
+  uint32 successful_nodes = 2; // Number of nodes successfully processed
+  uint32 failed_nodes = 3;     // Number of nodes that failed
+}
+
 // NodeBatchResponse reports the common result shape for multi-node RPCs.
 message NodeBatchResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;                // RETURN_CODE_SUCCESS only if all targeted nodes completed
   string message = 3;                   // Human-readable summary message
-  uint32 total_nodes = 4;               // Total number of nodes targeted
-  uint32 successful_nodes = 5;          // Number of nodes successfully processed
-  uint32 failed_nodes = 6;              // Number of nodes that failed
-  repeated NodeResult node_results = 7; // Individual results for each node
+  repeated NodeOperationResult node_results = 7; // Individual results for each node
   string job_id = 8;                    // Parent job ID for async batch operations
+  NodeOperationStats stats = 9;         // Aggregate node counts
 }
 
 /*******************************************************************************
@@ -293,10 +288,10 @@ service RackManager {
   rpc SetPowerState(SetPowerStateRequest) returns (SetPowerStateResponse) {}
 
   /*
-   * SetPowerStateByNodeList controls power for caller-supplied nodes
-   * without requiring them to be registered in RMS inventory.
+   * BatchSetPowerState controls power for caller-supplied nodes without
+   * requiring them to be registered in RMS inventory.
    */
-  rpc SetPowerStateByNodeList(SetPowerStateByNodeListRequest) returns (SetPowerStateByNodeListResponse) {}
+  rpc BatchSetPowerState(BatchSetPowerStateRequest) returns (BatchSetPowerStateResponse) {}
 
   /*
    * GetPowerState retrieves the current power state of a node.
@@ -305,11 +300,11 @@ service RackManager {
   rpc GetPowerState(GetPowerStateRequest) returns (GetPowerStateResponse) {}
 
   /*
-   * GetPowerStateByNodeList retrieves the current power state for caller-
-   * supplied nodes without requiring them to be registered in RMS inventory.
+   * BatchGetPowerState retrieves the current power state for caller-supplied
+   * nodes without requiring them to be registered in RMS inventory.
    * Returns per-node power state along with batch status.
    */
-  rpc GetPowerStateByNodeList(GetPowerStateByNodeListRequest) returns (GetPowerStateByNodeListResponse) {}
+  rpc BatchGetPowerState(BatchGetPowerStateRequest) returns (BatchGetPowerStateResponse) {}
 
   /*
    * SequenceRackPower controls the power state of all nodes in a rack.
@@ -323,15 +318,15 @@ service RackManager {
    *-------------------------------------------------------------------------*/
 
   /*
-   * GetAllInventory retrieves the complete inventory of all nodes across all racks.
+   * ListNodeInventory retrieves the complete inventory of all nodes across all racks.
    */
-  rpc GetAllInventory(GetAllInventoryRequest) returns (GetAllInventoryResponse) {}
+  rpc ListNodeInventory(ListNodeInventoryRequest) returns (ListNodeInventoryResponse) {}
 
   /*
-   * AddNode registers one or more new nodes in the inventory.
+   * CreateNodes registers one or more new nodes in the inventory.
    * Supports batch addition of multiple nodes in a single request.
    */
-  rpc AddNode(AddNodeRequest) returns (AddNodeResponse) {}
+  rpc CreateNodes(CreateNodesRequest) returns (CreateNodesResponse) {}
 
   /*
    * UpdateNode modifies the configuration of an existing node.
@@ -340,9 +335,9 @@ service RackManager {
   rpc UpdateNode(UpdateNodeRequest) returns (UpdateNodeResponse) {}
 
   /*
-   * RemoveNode removes a node from the inventory. The node must exist in the specified rack.
-  */
-  rpc RemoveNode(RemoveNodeRequest) returns (RemoveNodeResponse) {}
+   * DeleteNode removes a node from the inventory. The node must exist in the specified rack.
+   */
+  rpc DeleteNode(DeleteNodeRequest) returns (DeleteNodeResponse) {}
 
   /*
    * GetRackPowerOnSequence retrieves the configured boot sequence for a rack.
@@ -358,7 +353,7 @@ service RackManager {
 
   /*
    * ListRacks returns a list of all rack IDs in the system.
-  */
+   */
   rpc ListRacks(ListRacksRequest) returns (ListRacksResponse) {}
 
   /*
@@ -367,16 +362,16 @@ service RackManager {
   rpc GetNodeDeviceInfo(GetNodeDeviceInfoRequest) returns (GetNodeDeviceInfoResponse) {}
 
   /*
-   * GetDeviceInfoByNodeType retrieves normalized device metadata for all nodes
-   * of a specific type in a rack.
+   * ListNodeDeviceInfoByNodeType retrieves normalized device metadata for all
+   * nodes of a specific type in a rack.
    */
-  rpc GetDeviceInfoByNodeType(GetDeviceInfoByNodeTypeRequest) returns (GetDeviceInfoByNodeTypeResponse) {}
+  rpc ListNodeDeviceInfoByNodeType(ListNodeDeviceInfoByNodeTypeRequest) returns (ListNodeDeviceInfoByNodeTypeResponse) {}
 
   /*
-   * GetDeviceInfoByNodeList retrieves normalized device metadata for a caller-
+   * BatchGetNodeDeviceInfo retrieves normalized device metadata for a caller-
    * supplied list of nodes. Each node is identified by its NodeInfo.
    */
-  rpc GetDeviceInfoByNodeList(GetDeviceInfoByNodeListRequest) returns (GetDeviceInfoByNodeListResponse) {}
+  rpc BatchGetNodeDeviceInfo(BatchGetNodeDeviceInfoRequest) returns (BatchGetNodeDeviceInfoResponse) {}
 
   /*---------------------------------------------------------------------------
    * Firmware Control RPCs
@@ -389,28 +384,28 @@ service RackManager {
   rpc GetNodeFirmwareInventory(GetNodeFirmwareInventoryRequest) returns (GetNodeFirmwareInventoryResponse) {}
 
   /*
-   * UpdateNodeFirmwareAsync initiates a firmware update on a specific node asynchronously.
+   * UpdateFirmware initiates a firmware update on a specific node asynchronously.
    * Returns a job ID immediately. Use GetFirmwareJobStatus to track progress.
    * Works for all node types (compute, powershelf, switch).
    */
-  rpc UpdateNodeFirmwareAsync(UpdateNodeFirmwareAsyncRequest) returns (UpdateNodeFirmwareAsyncResponse) {}
+  rpc UpdateFirmware(UpdateFirmwareRequest) returns (UpdateFirmwareResponse) {}
 
   /*
-   * UpdateFirmwareByNodeTypeAsync initiates firmware updates on all nodes of a specific
+   * BatchUpdateFirmwareByNodeType initiates firmware updates on all nodes of a specific
    * type in a rack asynchronously. Returns a parent job ID for tracking overall batch status,
    * along with individual node job IDs. Use GetFirmwareJobStatus to track progress.
    */
-  rpc UpdateFirmwareByNodeTypeAsync(UpdateFirmwareByNodeTypeAsyncRequest) returns (UpdateFirmwareByNodeTypeAsyncResponse) {}
+  rpc BatchUpdateFirmwareByNodeType(BatchUpdateFirmwareByNodeTypeRequest) returns (BatchUpdateFirmwareByNodeTypeResponse) {}
 
   /*
-   * UpdateFirmwareByNodeList initiates firmware updates on a specified list of nodes
+   * BatchUpdateFirmware initiates firmware updates on a specified list of nodes
    * asynchronously. Each node is identified by its NodeInfo. Separate firmware targets
    * are provided for compute trays, switch trays, and power shelves, and the appropriate target
    * is applied to each node based on its node type.
    * Returns a parent job ID for tracking overall batch status, along with individual node
    * job IDs. Use GetFirmwareJobStatus to track progress.
    */
-  rpc UpdateFirmwareByNodeList(UpdateFirmwareByNodeListRequest) returns (UpdateFirmwareByNodeListResponse) {}
+  rpc BatchUpdateFirmware(BatchUpdateFirmwareRequest) returns (BatchUpdateFirmwareResponse) {}
 
   /*
    * UpdateSwitchSystemImage initiates asynchronous switch system image updates on a caller-
@@ -433,12 +428,12 @@ service RackManager {
    * the object. Use GetFirmwareObject or ListFirmwareObjects and check
    * FirmwareObject.available before applying it.
    */
-  rpc AddFirmwareObject(AddFirmwareObjectRequest) returns (FirmwareObject) {}
+  rpc AddFirmwareObject(AddFirmwareObjectRequest) returns (AddFirmwareObjectResponse) {}
 
   /*
    * GetFirmwareObject retrieves one firmware object catalog entry.
    */
-  rpc GetFirmwareObject(GetFirmwareObjectRequest) returns (FirmwareObject) {}
+  rpc GetFirmwareObject(GetFirmwareObjectRequest) returns (GetFirmwareObjectResponse) {}
 
   /*
    * ListFirmwareObjects lists firmware object catalog entries.
@@ -448,67 +443,66 @@ service RackManager {
   /*
    * DeleteFirmwareObject removes one firmware object catalog entry and its local cache.
    */
-  rpc DeleteFirmwareObject(DeleteFirmwareObjectRequest) returns (OperationResponse) {}
+  rpc DeleteFirmwareObject(DeleteFirmwareObjectRequest) returns (DeleteFirmwareObjectResponse) {}
 
   /*
    * SetDefaultFirmwareObject marks one firmware object as default for its hardware type.
    */
-  rpc SetDefaultFirmwareObject(SetDefaultFirmwareObjectRequest) returns (FirmwareObject) {}
+  rpc SetDefaultFirmwareObject(SetDefaultFirmwareObjectRequest) returns (SetDefaultFirmwareObjectResponse) {}
 
   /*
-   * ApplyFirmwareObject resolves stored firmware targets and starts firmware updates for supplied nodes.
+   * ApplyStoredFirmwareObject resolves stored firmware targets and starts firmware updates for supplied nodes.
    */
-  rpc ApplyFirmwareObject(ApplyFirmwareObjectRequest) returns (ApplyFirmwareObjectResponse) {}
+  rpc ApplyStoredFirmwareObject(ApplyStoredFirmwareObjectRequest) returns (ApplyStoredFirmwareObjectResponse) {}
 
   /*
-   * ApplyFirmwareObjectFromJson ingests a firmware object from JSON, downloads required
+   * ApplyFirmwareObject ingests a firmware object from JSON, downloads required
    * artifacts, resolves firmware targets, and starts firmware updates for supplied nodes.
    *
    * RMS treats the ingested firmware object as ephemeral for this request. It uses
    * access_token only for artifact download and does not persist the token or object.
    */
-  rpc ApplyFirmwareObjectFromJson(ApplyFirmwareObjectFromJsonRequest) returns (ApplyFirmwareObjectFromJsonResponse) {}
+  rpc ApplyFirmwareObject(ApplyFirmwareObjectRequest) returns (ApplyFirmwareObjectResponse) {}
 
   /*
-   * ApplySwitchSystemImageFromJson ingests a firmware object from SOT JSON, downloads
-   * required artifacts, resolves the stored switch system image, and starts updates for
-   * supplied switches.
+   * ApplySwitchSystemImage ingests a firmware object from SOT JSON, downloads
+   * required artifacts, resolves the switch system image artifact from the ingested
+   * firmware object, and starts updates for supplied switches.
    *
    * RMS treats the ingested firmware object as ephemeral for this request. It uses
    * access_token only for artifact download and does not persist the token or object.
    */
-  rpc ApplySwitchSystemImageFromJson(ApplySwitchSystemImageFromJsonRequest) returns (ApplySwitchSystemImageFromJsonResponse) {}
+  rpc ApplySwitchSystemImage(ApplySwitchSystemImageRequest) returns (ApplySwitchSystemImageResponse) {}
 
   /*
-   * ApplySwitchSystemImage resolves a stored switch system image and starts updates for supplied switches.
+   * ApplyStoredSwitchSystemImage resolves a stored switch system image and starts updates for supplied switches.
    */
-  rpc ApplySwitchSystemImage(ApplySwitchSystemImageRequest) returns (ApplySwitchSystemImageResponse) {}
+  rpc ApplyStoredSwitchSystemImage(ApplyStoredSwitchSystemImageRequest) returns (ApplyStoredSwitchSystemImageResponse) {}
 
   /*
    * GetFirmwareObjectHistory lists firmware object apply history.
    */
   rpc GetFirmwareObjectHistory(GetFirmwareObjectHistoryRequest) returns (GetFirmwareObjectHistoryResponse) {}
 
-
   /*
-   * ListFirmwareOnSwitch lists the firmware for switch.
+   * ListSwitchFirmware lists the firmware for switch.
    * Returns version, update status, and health for switch firmware component.
    */
-   rpc ListFirmwareOnSwitch(ListFirmwareOnSwitchRequest) returns (ListFirmwareOnSwitchResponse) {}
+  rpc ListSwitchFirmware(ListSwitchFirmwareRequest) returns (ListSwitchFirmwareResponse) {}
 
-   /*
-   * PushFirmwareToSwitch Push a firmware binary to target Switch
+  /*
+   * PushSwitchFirmware pushes a firmware binary to target switch.
    * Returns success or error_message
    */
-   rpc PushFirmwareToSwitch(PushFirmwareToSwitchRequest) returns (PushFirmwareToSwitchResponse) {}
+  rpc PushSwitchFirmware(PushSwitchFirmwareRequest) returns (PushSwitchFirmwareResponse) {}
 
-   /*
-    * UpgradeFirmwareOnSwitch performs a complete firmware upgrade workflow for a switch component.
-    * This includes: checking current version, pushing firmware file, installing firmware,
-    * power cycling the switch, waiting for health, and verifying the new version.
-    * Returns the stage where upgrade failed (if any) along with error details.
-    */
-   rpc UpgradeFirmwareOnSwitch(UpgradeFirmwareOnSwitchRequest) returns (UpgradeFirmwareOnSwitchResponse) {}
+  /*
+   * UpgradeSwitchFirmware performs a complete firmware upgrade workflow for a switch component.
+   * This includes: checking current version, pushing firmware file, installing firmware,
+   * power cycling the switch, waiting for health, and verifying the new version.
+   * Returns the stage where upgrade failed (if any) along with error details.
+   */
+  rpc UpgradeSwitchFirmware(UpgradeSwitchFirmwareRequest) returns (UpgradeSwitchFirmwareResponse) {}
 
   /*---------------------------------------------------------------------------
    * Scale Up switch control RPCs
@@ -523,16 +517,16 @@ service RackManager {
   rpc ConfigureScaleUpFabricManager(ConfigureScaleUpFabricManagerRequest) returns (ConfigureScaleUpFabricManagerResponse) {}
 
   /*
-   * SetScaleUpFabricState synchronously sets ScaleUpFabric state and saves
+   * BatchSetScaleUpFabricState synchronously sets ScaleUpFabric state and saves
    * config across all supplied switches.
    */
-  rpc SetScaleUpFabricState(SetScaleUpFabricStateRequest) returns (SetScaleUpFabricStateResponse) {}
+  rpc BatchSetScaleUpFabricState(BatchSetScaleUpFabricStateRequest) returns (BatchSetScaleUpFabricStateResponse) {}
 
   /*
-   * GetScaleUpFabricServicesStatus retrieves cluster health and fabric-manager status
+   * BatchGetScaleUpFabricServiceStatus retrieves cluster health and fabric-manager status
    * for a caller-supplied list of switches using switch Rest APIs.
    */
-  rpc GetScaleUpFabricServicesStatus(GetScaleUpFabricServicesStatusRequest) returns (GetScaleUpFabricServicesStatusResponse) {}
+  rpc BatchGetScaleUpFabricServiceStatus(BatchGetScaleUpFabricServiceStatusRequest) returns (BatchGetScaleUpFabricServiceStatusResponse) {}
 
   /*
    * GetScaleUpFabricState retrieves the cluster state for a caller-supplied switch
@@ -541,10 +535,10 @@ service RackManager {
   rpc GetScaleUpFabricState(GetScaleUpFabricStateRequest) returns (GetScaleUpFabricStateResponse) {}
 
   /*
-   * EnableScaleUpFabricTelemetryInterface enables or disables the FabricTelemetryInterface service.
+   * SetScaleUpFabricTelemetryInterfaceState enables or disables the FabricTelemetryInterface service.
    * FabricTelemetryInterface provides streaming telemetry and configuration management capabilities.
    */
-  rpc EnableScaleUpFabricTelemetryInterface(EnableScaleUpFabricTelemetryInterfaceRequest) returns (EnableScaleUpFabricTelemetryInterfaceResponse) {}
+  rpc SetScaleUpFabricTelemetryInterfaceState(SetScaleUpFabricTelemetryInterfaceStateRequest) returns (SetScaleUpFabricTelemetryInterfaceStateResponse) {}
 
   /*---------------------------------------------------------------------------
    * Switch Control RPCs
@@ -587,14 +581,14 @@ service RackManager {
    *-------------------------------------------------------------------------*/
 
   /*
-   * Version returns server version information.
+   * GetVersion returns server version information.
    */
-  rpc Version(VersionRequest) returns (VersionResponse) {}
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {}
 
   /*
-   * PollJobStatus poll given job id in an interval.
+   * PollSwitchFirmwareJobStatus polls given job id in an interval.
    */
-   rpc PollJobStatus(PollJobStatusRequest) returns (PollJobStatusResponse) {}
+  rpc PollSwitchFirmwareJobStatus(PollSwitchFirmwareJobStatusRequest) returns (PollSwitchFirmwareJobStatusResponse) {}
 
   /*
    * GetFirmwareJobStatus retrieves the current status of an asynchronous firmware job.
@@ -611,8 +605,6 @@ service RackManager {
 
 // SetPowerStateRequest controls the power state of a single node.
 message SetPowerStateRequest {
-  reserved 1;
-  reserved "metadata";
   string node_id = 2;           // Target node identifier
   PowerOperation operation = 3; // Power operation to perform
   string rack_id = 4;           // Rack containing the target node
@@ -620,36 +612,28 @@ message SetPowerStateRequest {
 
 // SetPowerStateResponse confirms the power operation result.
 message SetPowerStateResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;   // RETURN_CODE_SUCCESS if power operation completed, RETURN_CODE_FAILURE otherwise
 }
 
-// SetPowerStateByNodeListRequest controls power for unregistered nodes.
-message SetPowerStateByNodeListRequest {
-  reserved 1;
-  reserved "metadata";
+// BatchSetPowerStateRequest controls power for unregistered nodes.
+message BatchSetPowerStateRequest {
   NodeSet nodes = 2;             // Caller-supplied node connection details
   PowerOperation operation = 3;  // Power operation to perform
 }
 
-// SetPowerStateByNodeListResponse reports per-node power operation results.
-message SetPowerStateByNodeListResponse {
+// BatchSetPowerStateResponse reports per-node power operation results.
+message BatchSetPowerStateResponse {
   NodeBatchResponse response = 1;
 }
 
 // GetPowerStateRequest queries the current power state of a node.
 message GetPowerStateRequest {
-  reserved 1;
-  reserved "metadata";
   string node_id = 2;     // Target node identifier
   string rack_id = 3;     // Rack containing the target node
 }
 
 // GetPowerStateResponse returns the current power state of a node.
 message GetPowerStateResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;   // RETURN_CODE_SUCCESS if query completed, RETURN_CODE_FAILURE otherwise
   string node_id = 3;      // Node identifier (echoed from request)
   string pstate = 4;       // Current power state: "ON", "OFF", or "UNKNOWN"
@@ -662,31 +646,25 @@ message NodePowerState {
   string pstate = 2;   // Current power state: "ON", "OFF", or "UNKNOWN"
 }
 
-// GetPowerStateByNodeListRequest queries power state for unregistered nodes.
-message GetPowerStateByNodeListRequest {
-  reserved 1;
-  reserved "metadata";
+// BatchGetPowerStateRequest queries power state for unregistered nodes.
+message BatchGetPowerStateRequest {
   NodeSet nodes = 2;  // Caller-supplied node connection details
 }
 
-// GetPowerStateByNodeListResponse reports per-node power state results.
-message GetPowerStateByNodeListResponse {
+// BatchGetPowerStateResponse reports per-node power state results.
+message BatchGetPowerStateResponse {
   NodeBatchResponse response = 1;
   repeated NodePowerState node_power_states = 2;  // Power state for each successfully queried node
 }
 
-// RackPowerRequest controls power for all nodes in a rack.
+// SequenceRackPowerRequest controls power for all nodes in a rack.
 message SequenceRackPowerRequest {
-  reserved 1;
-  reserved "metadata";
   RackPowerOperation operation = 2; // Rack-wide power operation to perform
   string rack_id = 3;               // Target rack identifier
 }
 
 // SequenceRackPowerResponse confirms the rack power operation result.
 message SequenceRackPowerResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;   // RETURN_CODE_SUCCESS if operation completed, RETURN_CODE_FAILURE otherwise
   string message = 3;      // Human-readable status or error message
 }
@@ -695,35 +673,28 @@ message SequenceRackPowerResponse {
  * INVENTORY CONTROL MESSAGES
  ******************************************************************************/
 
-// GetInventoryRequest retrieves the complete system inventory.
-message GetAllInventoryRequest {
-  reserved 1;
-  reserved "metadata";
+// ListNodeInventoryRequest retrieves the complete system inventory.
+message ListNodeInventoryRequest {
 }
 
-// GetInventoryResponse returns all nodes and their components.
-message GetAllInventoryResponse {
-  reserved 1, 2;
-  reserved "metadata", "status";
+// ListNodeInventoryResponse returns all nodes and their components.
+message ListNodeInventoryResponse {
   repeated NodeInventoryInfo nodes = 3; // Complete list of nodes across all racks
 }
 
-// AddNodeRequest registers new nodes in the inventory.
-message AddNodeRequest {
-  reserved 1;
-  reserved "metadata";
+// CreateNodesRequest registers new nodes in the inventory.
+message CreateNodesRequest {
   NodeSet nodes = 2; // List of nodes to add (batch operation supported)
 }
 
-// AddNodeResponse reports the results of adding nodes.
-message AddNodeResponse {
+// CreateNodesResponse reports the results of adding nodes.
+message CreateNodesResponse {
   OperationResponse response = 1;
+  NodeOperationStats stats = 2; // Aggregate add-node counts
 }
 
 // UpdateNodeRequest modifies an existing node's configuration.
 message UpdateNodeRequest {
-  reserved 1;
-  reserved "metadata";
   string node_id = 2;             // Target node identifier
   NodeUpdateInfo update_info = 3; // Fields to update (only set fields are changed)
   string rack_id = 4;             // Rack containing the target node
@@ -734,109 +705,87 @@ message UpdateNodeResponse {
   OperationResponse response = 1;
 }
 
-// RemoveNodeRequest deletes a node from the inventory.
-message RemoveNodeRequest {
-  reserved 1;
-  reserved "metadata";
+// DeleteNodeRequest deletes a node from the inventory.
+message DeleteNodeRequest {
   string node_id = 2;     // Target node identifier to remove
   string rack_id = 3;     // Rack containing the target node
 }
 
-// RemoveNodeResponse confirms the removal result.
-message RemoveNodeResponse {
+// DeleteNodeResponse confirms the removal result.
+message DeleteNodeResponse {
   OperationResponse response = 1;
 }
 
-// GetPowerOnOrderRequest retrieves the boot sequence for a rack.
+// GetRackPowerOnSequenceRequest retrieves the boot sequence for a rack.
 message GetRackPowerOnSequenceRequest {
-  reserved 1;
-  reserved "metadata";
   string rack_id = 2;     // Target rack identifier
 }
 
-// GetPowerOnOrderResponse returns the configured boot sequence.
+// GetRackPowerOnSequenceResponse returns the configured boot sequence.
 message GetRackPowerOnSequenceResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;                        // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated PowerOnOrderItem power_on_order = 3; // Ordered list of nodes for boot sequence
   bool is_valid = 4;                            // Whether the power-on order is valid for use
 }
 
-// SetPowerOnOrderRequest configures the boot sequence for a rack.
+// SetRackPowerOnSequenceRequest configures the boot sequence for a rack.
 message SetRackPowerOnSequenceRequest {
-  reserved 1;
-  reserved "metadata";
   repeated PowerOnOrderItem power_on_order = 2; // Ordered list of nodes for boot sequence
   string rack_id = 3;                           // Target rack identifier
 }
 
-// SetPowerOnOrderResponse confirms the configuration result.
+// SetRackPowerOnSequenceResponse confirms the configuration result.
 message SetRackPowerOnSequenceResponse {
   OperationResponse response = 1;
 }
 
 // ListRacksRequest retrieves all rack identifiers.
 message ListRacksRequest {
-  reserved 1;
-  reserved "metadata";
 }
 
 // ListRacksResponse returns all rack identifiers in the system.
 message ListRacksResponse {
-  reserved 1, 2;
-  reserved "metadata", "status";
   repeated string rack_ids = 3; // List of all rack identifiers
 }
 
 // GetNodeDeviceInfoRequest retrieves normalized device metadata for a specific node.
 message GetNodeDeviceInfoRequest {
-  reserved 1;
-  reserved "metadata";
   string rack_id = 2;     // Rack containing the target node
   string node_id = 3;     // Target node identifier
 }
 
 // GetNodeDeviceInfoResponse returns normalized device metadata for a specific node.
 message GetNodeDeviceInfoResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;      // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string message = 3;         // Human-readable status or error message
   NodeDeviceInfo device_info = 4; // Normalized device metadata for the node
 }
 
-// GetDeviceInfoByNodeTypeRequest retrieves device metadata for all nodes of a type in a rack.
-message GetDeviceInfoByNodeTypeRequest {
-  reserved 1;
-  reserved "metadata";
+// ListNodeDeviceInfoByNodeTypeRequest retrieves device metadata for all nodes of a type in a rack.
+message ListNodeDeviceInfoByNodeTypeRequest {
   string rack_id = 2;     // Target rack identifier
   NodeType node_type = 3; // Type of nodes to query
 }
 
-// GetDeviceInfoByNodeTypeResponse returns device metadata for all matching nodes in a rack.
-message GetDeviceInfoByNodeTypeResponse {
-  reserved 1;
-  reserved "metadata";
+// ListNodeDeviceInfoByNodeTypeResponse returns device metadata for all matching nodes in a rack.
+message ListNodeDeviceInfoByNodeTypeResponse {
   ReturnCode status = 2;                      // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string message = 3;                         // Human-readable status or error message
-  repeated NodeDeviceInfo node_device_info = 4; // Device metadata grouped by node
+  repeated NodeDeviceInfo node_device_details = 4; // Device metadata details grouped by node
+  NodeOperationStats stats = 5;               // Aggregate query counts
 }
 
-// GetDeviceInfoByNodeListRequest retrieves device metadata for a specified list of nodes.
-message GetDeviceInfoByNodeListRequest {
-  reserved 1;
-  reserved "metadata";
+// BatchGetNodeDeviceInfoRequest retrieves device metadata for a specified list of nodes.
+message BatchGetNodeDeviceInfoRequest {
   NodeSet nodes = 2;  // Nodes to query
 }
 
-// GetDeviceInfoByNodeListResponse returns device metadata for the requested nodes.
-message GetDeviceInfoByNodeListResponse {
-  reserved 1;
-  reserved "metadata";
+// BatchGetNodeDeviceInfoResponse returns device metadata for the requested nodes.
+message BatchGetNodeDeviceInfoResponse {
   ReturnCode status = 2;                      // RETURN_CODE_SUCCESS if all requested nodes succeeded, RETURN_CODE_FAILURE otherwise
   string message = 3;                         // Batch summary; includes per-node failure details when any node fails
-  repeated NodeDeviceInfo node_device_info = 4; // Successful device info results
+  repeated NodeDeviceInfo node_device_details = 4; // Successful device metadata details
+  NodeOperationStats stats = 5;               // Aggregate query counts
 }
 
 
@@ -846,16 +795,12 @@ message GetDeviceInfoByNodeListResponse {
 
 // GetNodeFirmwareInventoryRequest retrieves firmware info for a specific node.
 message GetNodeFirmwareInventoryRequest {
-  reserved 1;
-  reserved "metadata";
   string node_id = 2;     // Target node identifier
   string rack_id = 3;     // Rack containing the target node
 }
 
 // GetNodeFirmwareInventoryResponse returns firmware component information.
 message GetNodeFirmwareInventoryResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;                            // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated FirmwareInventoryInfo firmware_list = 3; // List of firmware components on the node
 }
@@ -876,12 +821,10 @@ message FirmwareObjectComponentFilter {
   repeated string components = 1; // Optional component filter for one node type
 }
 
-// UpdateNodeFirmwareAsyncRequest initiates a firmware update on a node.
+// UpdateFirmwareRequest initiates a firmware update on a node.
 // Supports single target (filename + target fields) or multiple targets (firmware_targets list).
 // If firmware_targets is non-empty, it takes precedence over the single filename/target fields.
-message UpdateNodeFirmwareAsyncRequest {
-  reserved 1;
-  reserved "metadata";
+message UpdateFirmwareRequest {
   string node_id = 2;     // Target node identifier
   string filename = 3;    // Single firmware filename (used when firmware_targets is empty)
   string target = 4;      // Single Redfish target URI (used when firmware_targets is empty)
@@ -891,22 +834,18 @@ message UpdateNodeFirmwareAsyncRequest {
   bool force_update = 8;  // Force the BMC to accept the firmware even if it's a downgrade
 }
 
-// UpdateNodeFirmwareAsyncResponse reports the firmware update result.
-message UpdateNodeFirmwareAsyncResponse {
-  reserved 1;
-  reserved "metadata";
+// UpdateFirmwareResponse reports the firmware update result.
+message UpdateFirmwareResponse {
   ReturnCode status = 2;              // RETURN_CODE_SUCCESS if update completed, RETURN_CODE_FAILURE otherwise
   string message = 3;                 // Human-readable status or error message
   FirmwareUpdateError error_code = 4; // Detailed error code for troubleshooting
   string job_id = 5; // Job ID for async operations (use with GetFirmwareJobStatus to track progress)
 }
 
-// UpdateFirmwareByNodeTypeAsyncRequest updates firmware on all nodes of a type.
+// BatchUpdateFirmwareByNodeTypeRequest updates firmware on all nodes of a type.
 // Supports single target (filename + target fields) or multiple targets (firmware_targets list).
 // If firmware_targets is non-empty, it takes precedence over the single filename/target fields.
-message UpdateFirmwareByNodeTypeAsyncRequest {
-  reserved 1;
-  reserved "metadata";
+message BatchUpdateFirmwareByNodeTypeRequest {
   NodeType node_type = 2; // Type of nodes to update
   string filename = 3;    // Single firmware filename (used when firmware_targets is empty)
   string target = 4;      // Single Redfish target URI (used when firmware_targets is empty)
@@ -922,31 +861,27 @@ message NodeFirmwareJobInfo {
   string job_id = 2;   // Firmware job ID returned for this node
 }
 
-// UpdateFirmwareByNodeTypeAsyncResponse reports the created async jobs.
-message UpdateFirmwareByNodeTypeAsyncResponse {
-  reserved 1;
-  reserved "metadata";
+// BatchUpdateFirmwareByNodeTypeResponse reports the created async jobs.
+message BatchUpdateFirmwareByNodeTypeResponse {
   ReturnCode status = 2;                            // RETURN_CODE_SUCCESS if jobs created, RETURN_CODE_FAILURE otherwise
   string message = 3;                               // Human-readable summary message
   string job_id = 4;                                // Parent job ID for the overall batch (use with GetFirmwareJobStatus)
-  uint32 total_nodes = 5;                           // Total number of nodes targeted
   repeated NodeFirmwareJobInfo jobs = 6;            // Individual job ID per node
+  NodeOperationStats stats = 7;                     // Aggregate job creation counts
 }
 
-// UpdateFirmwareByNodeListRequest initiates firmware updates on a specified list of nodes.
+// BatchUpdateFirmwareRequest initiates firmware updates on a specified list of nodes.
 // Firmware targets are provided per node type.
 // The appropriate firmware targets are applied to each node based on its node type.
-message UpdateFirmwareByNodeListRequest {
-  reserved 1;
-  reserved "metadata";
+message BatchUpdateFirmwareRequest {
   NodeSet nodes = 2;                                   // Nodes to update
   map<int32, FirmwareTargetList> firmware_targets = 3; // Firmware targets keyed by NodeType enum value
   bool activate = 4;                                   // Whether to activate firmware after installation
   bool force_update = 5;                               // Force the BMC to accept the firmware even if it's a downgrade
 }
 
-// UpdateFirmwareByNodeListResponse reports firmware update results.
-message UpdateFirmwareByNodeListResponse {
+// BatchUpdateFirmwareResponse reports firmware update results.
+message BatchUpdateFirmwareResponse {
   NodeBatchResponse response = 1;
   repeated NodeFirmwareJobInfo jobs = 2; // Individual job ID per node
 }
@@ -959,8 +894,6 @@ message SwitchSystemImageUpdateJobInfo {
 
 // UpdateSwitchSystemImageRequest initiates switch system image updates on a specified list of switches.
 message UpdateSwitchSystemImageRequest {
-  reserved 1;
-  reserved "metadata";
   NodeSet nodes = 2;            // Switch nodes to update
   string image_filename = 3;    // Binary filename as it should exist on the switch
   string local_file_path = 4;   // Local file path on the RMS host
@@ -974,15 +907,11 @@ message UpdateSwitchSystemImageResponse {
 
 // GetRackFirmwareInventoryRequest retrieves firmware for all nodes in a rack.
 message GetRackFirmwareInventoryRequest {
-  reserved 1;
-  reserved "metadata";
   string rack_id = 2;     // Target rack identifier
 }
 
 // GetRackFirmwareInventoryResponse returns firmware info for all nodes.
 message GetRackFirmwareInventoryResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;                    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated NodeFirmwareInventory nodes = 3; // Firmware inventory grouped by node
 }
@@ -1016,7 +945,7 @@ message FirmwareObjectDeviceComponents {
 
 // FirmwareObjectComponent describes one normalized component clients can request.
 message FirmwareObjectComponent {
-  string name = 1;           // Normalized component name accepted by ApplyFirmwareObject
+  string name = 1;           // Normalized component name accepted by firmware object apply requests
   string version = 2;
   string bundle = 3;
   string source_component = 4; // Raw component label from the firmware object
@@ -1049,8 +978,6 @@ message FirmwareObjectSwitchSystemImage {
 
 // AddFirmwareObjectRequest adds firmware object config and authorizes RMS artifact download.
 message AddFirmwareObjectRequest {
-  reserved 1;
-  reserved "metadata";
   string config_json = 2;
   // Used only for immediate/background artifact download; RMS does not persist this token.
   string access_token = 3;
@@ -1059,15 +986,19 @@ message AddFirmwareObjectRequest {
   bool set_default = 5;
 }
 
+message AddFirmwareObjectResponse {
+  FirmwareObject object = 1;
+}
+
 message GetFirmwareObjectRequest {
-  reserved 1;
-  reserved "metadata";
   string id = 2;
 }
 
+message GetFirmwareObjectResponse {
+  FirmwareObject object = 1;
+}
+
 message ListFirmwareObjectsRequest {
-  reserved 1;
-  reserved "metadata";
   bool only_available = 2;
   string hardware_type = 3;
 }
@@ -1077,21 +1008,23 @@ message ListFirmwareObjectsResponse {
 }
 
 message DeleteFirmwareObjectRequest {
-  reserved 1;
-  reserved "metadata";
   string id = 2;
 }
 
+message DeleteFirmwareObjectResponse {
+  OperationResponse response = 1;
+}
+
 message SetDefaultFirmwareObjectRequest {
-  reserved 1;
-  reserved "metadata";
   // Default scope is determined by the hardware_type stored on this object.
   string object_id = 2;
 }
 
-message ApplyFirmwareObjectRequest {
-  reserved 1;
-  reserved "metadata";
+message SetDefaultFirmwareObjectResponse {
+  FirmwareObject object = 1;
+}
+
+message ApplyStoredFirmwareObjectRequest {
   string rack_id = 2;
   string object_id = 3;          // Empty means use default for hardware_type
   string firmware_type = 4;        // "dev" or "prod"
@@ -1104,15 +1037,13 @@ message ApplyFirmwareObjectRequest {
   map<int32, FirmwareObjectComponentFilter> component_filters = 9;
 }
 
-message ApplyFirmwareObjectResponse {
+message ApplyStoredFirmwareObjectResponse {
   NodeBatchResponse response = 1;          // response.job_id is parent job id
   string object_id = 2;
   repeated NodeFirmwareJobInfo jobs = 3;
 }
 
-message ApplyFirmwareObjectFromJsonRequest {
-  reserved 1;
-  reserved "metadata";
+message ApplyFirmwareObjectRequest {
   string rack_id = 2;
   string config_json = 3;         // SOT JSON containing the firmware object ID and artifacts
   string access_token = 4;        // Used only for artifact download; RMS does not persist it
@@ -1125,20 +1056,34 @@ message ApplyFirmwareObjectFromJsonRequest {
   map<int32, FirmwareObjectComponentFilter> component_filters = 9;
 }
 
-message ApplyFirmwareObjectFromJsonResponse {
+message ApplyFirmwareObjectResponse {
   NodeBatchResponse response = 1;          // response.job_id is parent job id
   string object_id = 2;
   repeated NodeFirmwareJobInfo jobs = 3;
 }
 
-message ApplySwitchSystemImageRequest {
-  reserved 1;
-  reserved "metadata";
+message ApplyStoredSwitchSystemImageRequest {
   string rack_id = 2;
   string object_id = 3;    // Empty means use default for hardware_type
   string software_type = 4; // "dev" or "prod"
   string hardware_type = 5;
   NodeSet nodes = 6;         // Caller-supplied switch nodes
+}
+
+message ApplyStoredSwitchSystemImageResponse {
+  NodeBatchResponse response = 1;                       // response.job_id is parent job id
+  string object_id = 2;
+  string image_filename = 3;
+  repeated SwitchSystemImageUpdateJobInfo jobs = 4;
+}
+
+message ApplySwitchSystemImageRequest {
+  string rack_id = 2;
+  string config_json = 3;       // SOT JSON containing the firmware object ID and switch image
+  string access_token = 4;      // Used only for artifact download; RMS does not persist it
+  string software_type = 5;     // "dev" or "prod"
+  string hardware_type = 6;
+  NodeSet nodes = 7;            // Caller-supplied switch nodes
 }
 
 message ApplySwitchSystemImageResponse {
@@ -1148,27 +1093,7 @@ message ApplySwitchSystemImageResponse {
   repeated SwitchSystemImageUpdateJobInfo jobs = 4;
 }
 
-message ApplySwitchSystemImageFromJsonRequest {
-  reserved 1;
-  reserved "metadata";
-  string rack_id = 2;
-  string config_json = 3;       // SOT JSON containing the firmware object ID and switch image
-  string access_token = 4;      // Used only for artifact download; RMS does not persist it
-  string software_type = 5;     // "dev" or "prod"
-  string hardware_type = 6;
-  NodeSet nodes = 7;            // Caller-supplied switch nodes
-}
-
-message ApplySwitchSystemImageFromJsonResponse {
-  NodeBatchResponse response = 1;                       // response.job_id is parent job id
-  string object_id = 2;
-  string image_filename = 3;
-  repeated SwitchSystemImageUpdateJobInfo jobs = 4;
-}
-
 message GetFirmwareObjectHistoryRequest {
-  reserved 1;
-  reserved "metadata";
   string object_id = 2;       // Empty means no object filter
   repeated string rack_ids = 3; // Empty means all racks
 }
@@ -1189,6 +1114,9 @@ message FirmwareObjectHistoryRecord {
 
 /*******************************************************************************
  * Switch ScaleUpFabricServices CONTROL MESSAGES
+ *
+ * Direct switch requests use node.host_endpoint for host address, credentials,
+ * and TLS certificate validation behavior.
  ******************************************************************************/
 
 /*
@@ -1196,17 +1124,12 @@ message FirmwareObjectHistoryRecord {
  * This operation enables the ScaleUpFabricManager, configures ScaleUpFabricManager access, and sets topology.
  */
 message ConfigureScaleUpFabricManagerRequest {
-  reserved 1;
-  reserved "metadata";
   NodeInfo node = 2;        // Target switch identity and direct connection information
   string topology_type = 3;    // Topology to be set for ScaleUpFabric
-  bool verify_ssl = 4;         // Whether to verify SSL certificates for HTTPS connections
 }
 
 // ConfigureScaleUpFabricManagerResponse reports the ScaleUpFabricManager  configuration result.
 message ConfigureScaleUpFabricManagerResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;      // RETURN_CODE_SUCCESS if configuration completed, RETURN_CODE_FAILURE otherwise
   string message = 3;         // Human-readable status or error message
   string topology_used = 4;   // multi-node scaleup topology that was applied
@@ -1215,19 +1138,16 @@ message ConfigureScaleUpFabricManagerResponse {
 }
 
 /*
- * SetScaleUpFabricStateRequest performs synchronous ScaleUpFabric state update
+ * BatchSetScaleUpFabricStateRequest performs synchronous ScaleUpFabric state update
  * and config save across caller-supplied switches.
  */
-message SetScaleUpFabricStateRequest {
-  reserved 1;
-  reserved "metadata";
+message BatchSetScaleUpFabricStateRequest {
   NodeSet nodes = 2;       // Switch nodes to update
-  optional bool enabled = 3;  // true = enabled, false = disabled
-  bool verify_ssl = 4;     // Whether to verify SSL certificates for HTTPS connections
+  bool enabled = 3;        // true = enabled, false/unset = disabled
 }
 
-// SetScaleUpFabricStateResponse reports the synchronous per-switch result.
-message SetScaleUpFabricStateResponse {
+// BatchSetScaleUpFabricStateResponse reports the synchronous per-switch result.
+message BatchSetScaleUpFabricStateResponse {
   NodeBatchResponse response = 1;  // response.job_id is unused and left empty for this synchronous RPC
 }
 
@@ -1237,34 +1157,25 @@ message ScaleUpFabricServiceStatusEntry {
   string error_message = 2; // Error details if query failed
 }
 
-// GetScaleUpFabricServicesStatusRequest checks cluster health and nmx-controller status on caller-supplied switches.
-message GetScaleUpFabricServicesStatusRequest {
-  reserved 1;
-  reserved "metadata";
+// BatchGetScaleUpFabricServiceStatusRequest checks cluster health and nmx-controller status on caller-supplied switches.
+message BatchGetScaleUpFabricServiceStatusRequest {
   NodeSet nodes = 2;      // Switch nodes to query
-  bool verify_ssl = 3;    // Whether to verify SSL certificates for HTTPS connections
 }
 
-// GetScaleUpFabricServicesStatusResponse reports per-switch results keyed by node_id.
-message GetScaleUpFabricServicesStatusResponse {
-  reserved 1;
-  reserved "metadata";
+// BatchGetScaleUpFabricServiceStatusResponse reports per-switch results keyed by node_id.
+message BatchGetScaleUpFabricServiceStatusResponse {
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
-  map<string, ScaleUpFabricServiceStatusEntry> device_info_result = 3; // key = node_id
+  map<string, ScaleUpFabricServiceStatusEntry> service_statuses = 3; // key = node_id
+  NodeOperationStats stats = 4; // Aggregate query counts
 }
 
 // GetScaleUpFabricStateRequest retrieves the ScaleUpFabric state for a single switch.
 message GetScaleUpFabricStateRequest {
-  reserved 1;
-  reserved "metadata";
   NodeInfo node = 2;     // Target switch identity and direct connection information
-  bool verify_ssl = 3;      // Whether to verify SSL certificates
 }
 
 // GetScaleUpFabricStateResponse returns the ScaleUpFabric state.
 message GetScaleUpFabricStateResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string state_json = 3;    // JSON object containing ScaleUpFabric state information
   string error_message = 4; // Error details if query failed
@@ -1279,8 +1190,6 @@ message GetScaleUpFabricStateResponse {
 
 // FetchSwitchSystemImageRequest downloads an OS image to a switch.
 message FetchSwitchSystemImageRequest {
-  reserved 1, 4, 5;
-  reserved "metadata", "port", "verify_ssl";
   string rack_id = 2;      // Rack containing the target switch
   string node_id = 3;      // Target switch node identifier
   string remote_url = 6;   // URL to download the system image from
@@ -1288,8 +1197,6 @@ message FetchSwitchSystemImageRequest {
 
 // FetchSwitchSystemImageResponse reports the download initiation result.
 message FetchSwitchSystemImageResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if download started, RETURN_CODE_FAILURE otherwise
   string job_id = 3;        // Job identifier for tracking download progress
   string error_message = 4; // Error details if download failed to start
@@ -1297,8 +1204,6 @@ message FetchSwitchSystemImageResponse {
 
 // InstallSwitchSystemImageRequest installs an OS image on a switch.
 message InstallSwitchSystemImageRequest {
-  reserved 1, 4, 5;
-  reserved "metadata", "port", "verify_ssl";
   string rack_id = 2;         // Rack containing the target switch
   string node_id = 3;         // Target switch node identifier
   string image_filename = 6;  // Filename of the image to install (must be fetched first)
@@ -1306,8 +1211,6 @@ message InstallSwitchSystemImageRequest {
 
 // InstallSwitchSystemImageResponse reports the installation initiation result.
 message InstallSwitchSystemImageResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if installation started, RETURN_CODE_FAILURE otherwise
   string job_id = 3;        // Job identifier for tracking installation progress
   string error_message = 4; // Error details if installation failed to start
@@ -1315,59 +1218,44 @@ message InstallSwitchSystemImageResponse {
 
 // ListSwitchSystemImagesRequest retrieves available OS images on a switch.
 message ListSwitchSystemImagesRequest {
-  reserved 1, 4, 5;
-  reserved "metadata", "port", "verify_ssl";
   string rack_id = 2;      // Rack containing the target switch
   string node_id = 3;      // Target switch node identifier
 }
 
 // ListSwitchSystemImagesResponse returns available OS images.
 message ListSwitchSystemImagesResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string images_json = 3;   // JSON array containing image information
   string error_message = 4; // Error details if query failed
 }
 
-// EnableScaleUpFabricTelemetryInterfaceRequest enables or disables the FabricTelemetryInterface.
-message EnableScaleUpFabricTelemetryInterfaceRequest {
-  reserved 1;
-  reserved "metadata";
+// SetScaleUpFabricTelemetryInterfaceStateRequest enables or disables the FabricTelemetryInterface.
+message SetScaleUpFabricTelemetryInterfaceStateRequest {
   NodeInfo node = 2;      // Target switch identity and direct connection information
   bool enable = 3;        // true to enable ScaleUpFabricTelemetryInterface, false to disable
-  bool verify_ssl = 4;    // Whether to verify SSL certificates
 }
 
-// EnableScaleUpFabricTelemetryInterfaceResponse reports the FabricTelemetryInterface status.
-message EnableScaleUpFabricTelemetryInterfaceResponse {
-  reserved 1;
-  reserved "metadata";
+// SetScaleUpFabricTelemetryInterfaceStateResponse reports the FabricTelemetryInterface status.
+message SetScaleUpFabricTelemetryInterfaceStateResponse {
   ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
   string result_json = 3;   // JSON object containing configuration result
   string error_message = 4; // Error details if configuration failed
 }
 
-message ListFirmwareOnSwitchRequest {
-  reserved 1, 5, 6;
-  reserved "metadata", "port", "verify_ssl";
+message ListSwitchFirmwareRequest {
   string rack_id = 2;                              // Rack ID for inventory lookup
   string node_id = 3;                              // Node ID for inventory lookup
   SwitchFirmwareComponentType component_type = 4;  // Required: Firmware component type enum
 }
 
-message ListFirmwareOnSwitchResponse {
-  reserved 1;
-  reserved "metadata";
-  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
-  string result_json = 3;   // JSON object containing configuration result
-  string error_message = 4; // Error details if configuration failed
+message ListSwitchFirmwareResponse {
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
+  string result_json = 3;   // JSON object containing firmware inventory result
+  string error_message = 4; // Error details if retrieval failed
 }
 
-// PushFirmwareToSwitch request/response
-message PushFirmwareToSwitchRequest {
-  reserved 1;
-  reserved "metadata";
+// PushSwitchFirmware request/response
+message PushSwitchFirmwareRequest {
   string rack_id = 2;                              // Required: Rack ID for inventory lookup
   string node_id = 3;                              // Required: Node ID for inventory lookup
   SwitchFirmwareComponentType component_type = 4;  // Required: Firmware component type enum
@@ -1375,27 +1263,21 @@ message PushFirmwareToSwitchRequest {
   string local_file_path = 6;                      // Required: Local file path on rackmanager host (file must be at least 1KB)
 }
 
-message PushFirmwareToSwitchResponse {
-  reserved 1;
-  reserved "metadata";
-  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
-  string result_json = 3;   // JSON object containing configuration result
-  string error_message = 4; // Error details if configuration failed
+message PushSwitchFirmwareResponse {
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if pushed, RETURN_CODE_FAILURE otherwise
+  string result_json = 3;   // JSON object containing push result
+  string error_message = 4; // Error details if push failed
 }
 
-// UpgradeFirmwareOnSwitchRequest performs complete firmware upgrade workflow for a switch component.
-message UpgradeFirmwareOnSwitchRequest {
-  reserved 1, 6, 7;
-  reserved "metadata", "port", "verify_ssl";
+// UpgradeSwitchFirmwareRequest performs complete firmware upgrade workflow for a switch component.
+message UpgradeSwitchFirmwareRequest {
   string rack_id = 2;                               // Rack ID for inventory lookup
   string node_id = 3;                               // Node ID for inventory lookup
-  SwitchFirmwareComponentType component = 4;             // Required: Firmware component type enum
+  SwitchFirmwareComponentType component_type = 4;        // Required: Firmware component type enum
   string filename = 5;                                   // Required: Local filesystem path to firmware file
 }
 
-message UpgradeFirmwareOnSwitchResponse {
-  reserved 1;
-  reserved "metadata";
+message UpgradeSwitchFirmwareResponse {
   ReturnCode status = 2;                                // RETURN_CODE_SUCCESS if upgrade completed, RETURN_CODE_FAILURE otherwise
   UpgradeStage failed_stage = 3;                         // Stage where upgrade failed (if status is RETURN_CODE_FAILURE)
   string error_message = 4;                             // Error details if upgrade failed (or summary message for multi-switch mode)
@@ -1404,9 +1286,7 @@ message UpgradeFirmwareOnSwitchResponse {
   string result_json = 7;                               // JSON array with detailed results for all switches (multi-switch mode only)
 }
 
-message PollJobStatusRequest {
-  reserved 1, 5, 6;
-  reserved "metadata", "port", "verify_ssl";
+message PollSwitchFirmwareJobStatusRequest {
   string rack_id = 2;               // Rack ID for inventory lookup
   string node_id = 3;               // Node ID for inventory lookup
   string job_id = 4;                // Job id for previously submitted job
@@ -1414,13 +1294,11 @@ message PollJobStatusRequest {
   uint32 poll_interval_seconds = 8; // Optional: Poll interval in seconds (default: 5)
 }
 
-message PollJobStatusResponse {
-  reserved 1;
-  reserved "metadata";
-  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
+message PollSwitchFirmwareJobStatusResponse {
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if polled, RETURN_CODE_FAILURE otherwise
   string state = 3;        // State of the job (active,pending,running)
-  string result_json = 4; // JSON object containing configuration result
-  string error_message = 5; // Error details if configuration failed
+  string result_json = 4; // JSON object containing job status result
+  string error_message = 5; // Error details if polling failed
 }
 
 /*******************************************************************************
@@ -1429,8 +1307,6 @@ message PollJobStatusResponse {
 
 // UpdateSwitchSystemPasswordRequest updates the OS-level password for a user on a set of switch nodes.
 message UpdateSwitchSystemPasswordRequest {
-  reserved 1;
-  reserved "metadata";
   NodeSet nodes = 2;       // Switch nodes to update
   string username = 3;     // Target OS username whose password will be changed (mandatory)
   string password = 4;     // New password to set for the user (mandatory)
@@ -1445,12 +1321,12 @@ message UpdateSwitchSystemPasswordResponse {
  * UTILITY MESSAGES
  ******************************************************************************/
 
-// VersionRequest retrieves server version information.
-message VersionRequest {
+// GetVersionRequest retrieves server version information.
+message GetVersionRequest {
 }
 
-// VersionResponse reports server version information.
-message VersionResponse {
+// GetVersionResponse reports server version information.
+message GetVersionResponse {
   string version = 1;
 }
 
@@ -1460,15 +1336,11 @@ message VersionResponse {
 
 // GetFirmwareJobStatusRequest queries the status of an asynchronous firmware job.
 message GetFirmwareJobStatusRequest {
-  reserved 1;
-  reserved "metadata";
-  string job_id = 2;       // Job ID returned from UpdateNodeFirmwareAsync or UpdateFirmwareByNodeTypeAsync
+  string job_id = 2;       // Job ID returned from UpdateFirmware or BatchUpdateFirmwareByNodeType
 }
 
 // GetFirmwareJobStatusResponse returns the current state of a firmware job.
 message GetFirmwareJobStatusResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;                 // RETURN_CODE_SUCCESS if job found, RETURN_CODE_FAILURE if job_id not found
   string job_id = 3;                     // Echoed job ID
   FirmwareJobState job_state = 4;        // Current state of the firmware job
@@ -1484,15 +1356,11 @@ message GetFirmwareJobStatusResponse {
 
 // GetSwitchSystemImageJobStatusRequest queries the status of an asynchronous switch system image job.
 message GetSwitchSystemImageJobStatusRequest {
-  reserved 1;
-  reserved "metadata";
   string job_id = 2;       // Parent or child job ID returned from UpdateSwitchSystemImage
 }
 
 // GetSwitchSystemImageJobStatusResponse returns the current state of a switch system image job.
 message GetSwitchSystemImageJobStatusResponse {
-  reserved 1;
-  reserved "metadata";
   ReturnCode status = 2;   // RETURN_CODE_SUCCESS if job found, RETURN_CODE_FAILURE if job_id not found
   string job_id = 3;       // Echoed job ID
   string state = 4;        // queued, running, completed, or failed

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -542,7 +542,8 @@ service RackManager {
 
   /*---------------------------------------------------------------------------
    * Switch Control RPCs
-   * Credentials are resolved from the node's stored inventory data.
+   * Connection settings, credentials, port, and TLS validation behavior are
+   * resolved from the node's stored inventory data.
    *-------------------------------------------------------------------------*/
 
   /*
@@ -863,11 +864,8 @@ message NodeFirmwareJobInfo {
 
 // BatchUpdateFirmwareByNodeTypeResponse reports the created async jobs.
 message BatchUpdateFirmwareByNodeTypeResponse {
-  ReturnCode status = 2;                            // RETURN_CODE_SUCCESS if jobs created, RETURN_CODE_FAILURE otherwise
-  string message = 3;                               // Human-readable summary message
-  string job_id = 4;                                // Parent job ID for the overall batch (use with GetFirmwareJobStatus)
-  repeated NodeFirmwareJobInfo jobs = 6;            // Individual job ID per node
-  NodeOperationStats stats = 7;                     // Aggregate job creation counts
+  NodeBatchResponse response = 1;
+  repeated NodeFirmwareJobInfo jobs = 2; // Individual job ID per node
 }
 
 // BatchUpdateFirmwareRequest initiates firmware updates on a specified list of nodes.
@@ -1185,7 +1183,8 @@ message GetScaleUpFabricStateResponse {
  * SWITCH CONTROL MESSAGES
  *
  * These messages are used for managing NVIDIA network switches via API.
- * Credentials are resolved from the node's stored inventory data.
+ * Connection settings, credentials, port, and TLS validation behavior are
+ * resolved from the node's stored inventory data.
  ******************************************************************************/
 
 // FetchSwitchSystemImageRequest downloads an OS image to a switch.

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -19,7 +19,6 @@ syntax = "proto3";
 
 package rack_manager;
 
-import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
 
 /*******************************************************************************
@@ -28,100 +27,98 @@ import "google/protobuf/timestamp.proto";
 
 // PowerOperation defines the power control actions for individual nodes.
 enum PowerOperation {
-  POWER_OFF               = 0;  // Power off the node using its default off semantics
-  POWER_ON                = 1;  // Power on the node
-  POWER_RESET             = 2;  // Power cycle the node
-  POWER_FORCE_OFF         = 3;  // Redfish ResetType ForceOff
-  POWER_FORCE_ON          = 4;  // Redfish ResetType ForceOn
-  POWER_GRACEFUL_SHUTDOWN = 5;  // Redfish ResetType GracefulShutdown
-  POWER_GRACEFUL_RESTART  = 6;  // Redfish ResetType GracefulRestart
-  POWER_FORCE_RESTART     = 7;  // Redfish ResetType ForceRestart
+  POWER_OPERATION_UNSPECIFIED       = 0;  // Caller left the operation missing or at the proto3 default
+  POWER_OPERATION_OFF               = 1;  // Power off the node using its default off semantics
+  POWER_OPERATION_ON                = 2;  // Power on the node
+  POWER_OPERATION_RESET             = 3;  // Power cycle the node
+  POWER_OPERATION_FORCE_OFF         = 4;  // Redfish ResetType ForceOff
+  POWER_OPERATION_FORCE_ON          = 5;  // Redfish ResetType ForceOn
+  POWER_OPERATION_GRACEFUL_SHUTDOWN = 6;  // Redfish ResetType GracefulShutdown
+  POWER_OPERATION_GRACEFUL_RESTART  = 7;  // Redfish ResetType GracefulRestart
+  POWER_OPERATION_FORCE_RESTART     = 8;  // Redfish ResetType ForceRestart
 }
 
-/* 
+/*
  * RackPowerOperation defines power control actions for an entire rack.
  * These operations respect the power-on order configuration for sequenced boot.
  */
 enum RackPowerOperation {
-  RACK_POWER_ON    = 0;  // Power on all nodes in the rack following power-on order
-  RACK_POWER_OFF   = 1;  // Power off all nodes in the rack
-  RACK_POWER_CYCLE = 2;  // Power cycle all nodes in the rack
+  RACK_POWER_OPERATION_UNSPECIFIED     = 0;  // Caller left the operation missing or at the proto3 default
+  RACK_POWER_OPERATION_ON              = 1;  // Power on all nodes in the rack following power-on order
+  RACK_POWER_OPERATION_OFF             = 2;  // Power off all nodes in the rack
+  RACK_POWER_OPERATION_CYCLE           = 3;  // Power cycle all nodes in the rack
 }
 
 // ReturnCode indicates the overall success or failure of an RPC operation.
 enum ReturnCode {
-  SUCCESS = 0;  // Operation completed successfully
-  FAILURE = 1;  // Operation failed (see message field for details)
+  RETURN_CODE_UNSPECIFIED = 0;  // Server left the status unset or at the proto3 default
+  RETURN_CODE_SUCCESS     = 1;  // Operation completed successfully
+  RETURN_CODE_FAILURE     = 2;  // Operation failed (see message field for details)
 }
 
 // FirmwareUpdateError provides detailed error codes for firmware update operations.
 enum FirmwareUpdateError {
-  FW_UPDATE_SUCCESS            = 0;   // Firmware update completed successfully
-  FW_UPDATE_FILE_NOT_FOUND     = 1;   // Specified firmware file does not exist
-  FW_UPDATE_CLIENT_FAILURE     = 2;   // HTTP/Redfish client communication failure
-  FW_UPDATE_TARGET_NOT_FOUND   = 3;   // Target component for update not found on node
-  FW_UPDATE_SERVER_ERROR       = 4;   // Server returned an error response
-  FW_UPDATE_TASK_FAILED        = 5;   // Firmware update task reported failure
-  FW_UPDATE_NO_TASK_INFO       = 6;   // Unable to retrieve task status information
-  FW_UPDATE_EXCEPTION          = 7;   // Exception occurred during update process
-  FW_UPDATE_INVALID_RESPONSE   = 8;   // Received invalid or malformed response
-  FW_UPDATE_MONITORING_TIMEOUT = 9;   // Timed out waiting for update to complete
-  FW_UPDATE_TASK_EXCEPTION     = 10;  // Exception in task monitoring
-  FW_UPDATE_UNKNOWN            = 11;  // Unknown or unclassified error
+  FIRMWARE_UPDATE_ERROR_UNSPECIFIED        = 0;   // Server left the error code unset or at the proto3 default
+  FIRMWARE_UPDATE_ERROR_SUCCESS            = 1;   // Firmware update completed successfully
+  FIRMWARE_UPDATE_ERROR_FILE_NOT_FOUND     = 2;   // Specified firmware file does not exist
+  FIRMWARE_UPDATE_ERROR_CLIENT_FAILURE     = 3;   // HTTP/Redfish client communication failure
+  FIRMWARE_UPDATE_ERROR_TARGET_NOT_FOUND   = 4;   // Target component for update not found on node
+  FIRMWARE_UPDATE_ERROR_SERVER_ERROR       = 5;   // Server returned an error response
+  FIRMWARE_UPDATE_ERROR_TASK_FAILED        = 6;   // Firmware update task reported failure
+  FIRMWARE_UPDATE_ERROR_NO_TASK_INFO       = 7;   // Unable to retrieve task status information
+  FIRMWARE_UPDATE_ERROR_EXCEPTION          = 8;   // Exception occurred during update process
+  FIRMWARE_UPDATE_ERROR_INVALID_RESPONSE   = 9;   // Received invalid or malformed response
+  FIRMWARE_UPDATE_ERROR_MONITORING_TIMEOUT = 10;  // Timed out waiting for update to complete
+  FIRMWARE_UPDATE_ERROR_TASK_EXCEPTION     = 11;  // Exception in task monitoring
+  FIRMWARE_UPDATE_ERROR_UNKNOWN            = 12;  // Unknown or unclassified error
 }
 
 // NodeType identifies the category of a node in the rack.
 enum NodeType {
-  NODE_TYPE_UNKNOWN    = 0;  // Unknown or unclassified node type
-  NODE_TYPE_COMPUTE    = 1;  // Compute node (GPU server, CPU server)
-  NODE_TYPE_POWERSHELF = 2;  // Power shelf (power distribution unit)
-  NODE_TYPE_SWITCH     = 3;  // Network switch
+  NODE_TYPE_UNSPECIFIED = 0;  // Caller left the node type missing or at the proto3 default
+  NODE_TYPE_UNKNOWN     = 1;  // Unknown or unclassified node type
+  NODE_TYPE_COMPUTE     = 2;  // Compute node (GPU server, CPU server)
+  NODE_TYPE_POWERSHELF  = 3;  // Power shelf (power distribution unit)
+  NODE_TYPE_SWITCH      = 4;  // Network switch
 }
 
 // SwitchFirmwareComponentType identifies the firmware component type on a switch.
 enum SwitchFirmwareComponentType {
-  SWITCH_FW_COMPONENT_UNKNOWN     = 0;  // Unknown component type
-  SWITCH_FW_COMPONENT_BMC         = 1;  // Baseboard Management Controller
-  SWITCH_FW_COMPONENT_FPGA        = 2;  // Field Programmable Gate Array
-  SWITCH_FW_COMPONENT_EROT        = 3;  // Embedded Root of Trust
-  SWITCH_FW_COMPONENT_CPLD        = 4;  // Complex Programmable Logic Device
-  SWITCH_FW_COMPONENT_BIOS        = 5;  // Basic Input/Output System
-  SWITCH_FW_COMPONENT_TRANSCEIVER = 6;  // Optical transceiver
+  SWITCH_FIRMWARE_COMPONENT_TYPE_UNSPECIFIED = 0;  // Caller left the component type missing or at the proto3 default
+  SWITCH_FIRMWARE_COMPONENT_TYPE_UNKNOWN     = 1;  // Unknown component type
+  SWITCH_FIRMWARE_COMPONENT_TYPE_BMC         = 2;  // Baseboard Management Controller
+  SWITCH_FIRMWARE_COMPONENT_TYPE_FPGA        = 3;  // Field Programmable Gate Array
+  SWITCH_FIRMWARE_COMPONENT_TYPE_EROT        = 4;  // Embedded Root of Trust
+  SWITCH_FIRMWARE_COMPONENT_TYPE_CPLD        = 5;  // Complex Programmable Logic Device
+  SWITCH_FIRMWARE_COMPONENT_TYPE_BIOS        = 6;  // Basic Input/Output System
+  SWITCH_FIRMWARE_COMPONENT_TYPE_TRANSCEIVER = 7;  // Optical transceiver
 }
 
 // FirmwareJobState represents the lifecycle state of an asynchronous firmware job.
 enum FirmwareJobState {
-  FW_JOB_QUEUED     = 0;  // Job has been created and is waiting to start
-  FW_JOB_RUNNING    = 1;  // Job is actively executing
-  FW_JOB_COMPLETED  = 2;  // Job finished successfully
-  FW_JOB_FAILED     = 3;  // Job finished with an error
+  FIRMWARE_JOB_STATE_UNSPECIFIED = 0;  // Server left the job state unset or at the proto3 default
+  FIRMWARE_JOB_STATE_QUEUED      = 1;  // Job has been created and is waiting to start
+  FIRMWARE_JOB_STATE_RUNNING     = 2;  // Job is actively executing
+  FIRMWARE_JOB_STATE_COMPLETED   = 3;  // Job finished successfully
+  FIRMWARE_JOB_STATE_FAILED      = 4;  // Job finished with an error
 }
 
 // UpgradeStage identifies the stage of firmware upgrade process on a switch.
 enum UpgradeStage {
-  UPGRADE_STAGE_UNKNOWN = 0;                    // Unknown stage
-  UPGRADE_STAGE_CHECK_CURRENT_VERSION = 1;      // Checking current firmware version
-  UPGRADE_STAGE_PUSH_FIRMWARE = 2;              // Pushing firmware file to switch
-  UPGRADE_STAGE_INSTALL_FIRMWARE = 3;           // Installing firmware on switch
-  UPGRADE_STAGE_POWER_CYCLE = 4;                // Power cycling the switch
-  UPGRADE_STAGE_WAIT_FOR_HEALTH = 5;            // Waiting for switch to become healthy
-  UPGRADE_STAGE_VERIFY_VERSION = 6;              // Verifying upgraded firmware version
-  UPGRADE_STAGE_COMPLETE = 7;                    // Upgrade completed successfully
+  UPGRADE_STAGE_UNSPECIFIED = 0;                // Server left the upgrade stage unset or at the proto3 default
+  UPGRADE_STAGE_UNKNOWN = 1;                    // Unknown stage
+  UPGRADE_STAGE_CHECK_CURRENT_VERSION = 2;      // Checking current firmware version
+  UPGRADE_STAGE_PUSH_FIRMWARE = 3;              // Pushing firmware file to switch
+  UPGRADE_STAGE_INSTALL_FIRMWARE = 4;           // Installing firmware on switch
+  UPGRADE_STAGE_POWER_CYCLE = 5;                // Power cycling the switch
+  UPGRADE_STAGE_WAIT_FOR_HEALTH = 6;            // Waiting for switch to become healthy
+  UPGRADE_STAGE_VERIFY_VERSION = 7;              // Verifying upgraded firmware version
+  UPGRADE_STAGE_COMPLETE = 8;                    // Upgrade completed successfully
 }
 
 /*******************************************************************************
  * COMMON MESSAGES
  ******************************************************************************/
-
-/*
- * Metadata is included in every request and response for tracing and debugging.
- * It enables correlation of requests with responses and tracking of message flow.
- */
-message Metadata {
-  int32 sender_id = 1;  // Identifier of the sending entity (client or server)
-  int64 timestamp = 2;  // Unix timestamp in milliseconds when message was created
-  int32 msg_id    = 3;  // Unique message identifier for request/response correlation
-}
 
 // Username and password pair.
 message UsernamePassword {
@@ -139,21 +136,21 @@ message Credentials {
 
 // A network interface with paired IP and MAC address.
 message NetworkInterface {
-  string ip_address = 1;
-  string mac_address = 2;
+  string ip_address = 1;  // IPv4 or IPv6 textual address
+  string mac_address = 2; // Text MAC address
 }
 
-// BMC connection info and credentials — for authenticating with the node's BMC (Redfish API).
+// BMC connection info and credentials for authenticating with the node's BMC (Redfish API).
 message BmcEndpoint {
   NetworkInterface interface = 1;  // BMC network interface (single NIC)
-  int32 port = 2;                  // Port number for BMC communication (default: 443)
+  uint32 port = 2;                 // Port number for BMC communication (default: 443, max: 65535)
   Credentials credentials = 3;
 }
 
-// Host connection info and credentials — for authenticating with the node's host/switch OS (e.g., SSH, SWITCH API).
+// Host connection info and credentials for authenticating with the node's host/switch OS (e.g., SSH, SWITCH API).
 message HostEndpoint {
   repeated NetworkInterface interfaces = 1;  // Host NICs (multiple supported)
-  int32 port = 2;                            // Port number for host communication
+  uint32 port = 2;                           // Port number for host communication (max: 65535)
   Credentials credentials = 3;
 }
 
@@ -161,8 +158,8 @@ message HostEndpoint {
  * SHARED DATA TYPES
  ******************************************************************************/
 
-// NewNodeInfo contains all information needed to register a new node in the inventory.
-message NewNodeInfo {
+// NodeInfo contains all information needed to describe a node.
+message NodeInfo {
   string node_id = 1;             // Unique identifier for the node within the rack
   string rack_id = 2;             // Identifier of the rack containing this node
   optional NodeType type = 3;     // Type/category of the node
@@ -170,9 +167,9 @@ message NewNodeInfo {
   optional HostEndpoint host_endpoint = 5;   // Host connection info and credentials
 }
 
-// NodeSet represents a collection of devices, reusable wherever a device list is needed.
+// NodeSet represents a collection of nodes, reusable wherever a node list is needed.
 message NodeSet {
-  repeated NewNodeInfo devices = 1;  // List of devices in the topology
+  repeated NodeInfo nodes = 1;  // List of nodes in the topology
 }
 
 /*
@@ -190,9 +187,9 @@ message NodeInventoryInfo {
   string product = 2;                       // Product name/model of the node
   string health = 3;                        // Health status
   string ip_address = 4;                    // IP address of the node's BMC
-  int32 port = 5;                           // Port number for BMC communication
+  uint32 port = 5;                          // Port number for BMC communication
   NodeType type = 6;                        // Type/category of the node
-  repeated DeviceInventoryInfo devices = 7; // List of devices/components within the node
+  repeated DeviceInventoryInfo components = 7; // List of components within the node
   string mac_address = 8;                   // MAC address of the node's BMC interface
   string rack_id = 9;                       // Identifier of the rack containing this node
   repeated string host_mac_addresses = 10;  // Vector of MAC addresses of the node's Host interfaces
@@ -203,8 +200,8 @@ message NodeInventoryInfo {
 message NodeDeviceInfo {
   string node_id = 1;             // Unique identifier for the node
   optional int64 chassis_sn = 2;  // Optional chassis serial number when available
-  optional int32 slot_number = 3; // Optional physical slot number in the rack topology
-  optional int32 tray_index = 4;  // Optional tray index when available
+  optional uint32 slot_number = 3; // Optional physical slot number in the rack topology
+  optional uint32 tray_index = 4;  // Optional tray index when available
 }
 
 // DeviceInventoryInfo represents inventory information for a device/component within a node.
@@ -223,7 +220,7 @@ message DeviceInventoryInfo {
 message FirmwareInventoryInfo {
   string name = 1;          // Name of the firmware component
   string version = 2;       // Current firmware version string
-  string updateable = 3;    // Whether firmware can be updated
+  bool updateable = 3;      // Whether firmware can be updated
   string target = 4;        // Target URI for firmware updates
   string health = 5;        // Health status of the firmware component
   int32  firmware_type = 6; // Type of firmware
@@ -238,7 +235,7 @@ message PowerOnOrderItem {
 // CompletionCheck configures how to verify a node has completed booting.
 message CompletionCheck {
   bool enabled = 1;           // Whether to wait for boot completion before proceeding
-  int32 timeout_seconds = 2;  // Maximum time to wait for boot completion
+  uint32 timeout_seconds = 2; // Maximum time to wait for boot completion
 }
 
 // NodeFirmwareInventory groups firmware information for a specific node.
@@ -249,26 +246,28 @@ message NodeFirmwareInventory {
 
 // OperationResponse reports the common result shape for simple RPCs.
 message OperationResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;  // SUCCESS if operation completed, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;  // RETURN_CODE_SUCCESS if operation completed, RETURN_CODE_FAILURE otherwise
   string message = 3;     // Human-readable status or error message
 }
 
 // NodeResult reports the outcome of an operation on a specific node.
 message NodeResult {
   string node_id = 1;        // Node that was targeted
-  ReturnCode status = 2;     // SUCCESS if this node completed, FAILURE otherwise
+  ReturnCode status = 2;     // RETURN_CODE_SUCCESS if this node completed, RETURN_CODE_FAILURE otherwise
   string error_message = 3;  // Human-readable error message for failures
 }
 
 // NodeBatchResponse reports the common result shape for multi-node RPCs.
 message NodeBatchResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                // SUCCESS only if all targeted nodes completed
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                // RETURN_CODE_SUCCESS only if all targeted nodes completed
   string message = 3;                   // Human-readable summary message
-  int32 total_nodes = 4;                // Total number of nodes targeted
-  int32 successful_nodes = 5;           // Number of nodes successfully processed
-  int32 failed_nodes = 6;               // Number of nodes that failed
+  uint32 total_nodes = 4;               // Total number of nodes targeted
+  uint32 successful_nodes = 5;          // Number of nodes successfully processed
+  uint32 failed_nodes = 6;              // Number of nodes that failed
   repeated NodeResult node_results = 7; // Individual results for each node
   string job_id = 8;                    // Parent job ID for async batch operations
 }
@@ -277,16 +276,16 @@ message NodeBatchResponse {
  * SERVICE DEFINITION
  *
  * RackManager provides gRPC APIs for managing compute racks, including power
- * control, inventory management, firmware updates, and network switch 
+ * control, inventory management, firmware updates, and network switch
  * configuration.
  ******************************************************************************/
 
 service RackManager {
-  
+
   /*---------------------------------------------------------------------------
    * Power Control RPCs
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * SetPowerState controls the power state of a single node.
    * Supports power on, power off, and power reset operations.
@@ -294,11 +293,11 @@ service RackManager {
   rpc SetPowerState(SetPowerStateRequest) returns (SetPowerStateResponse) {}
 
   /*
-   * SetPowerStateByDeviceList controls power for caller-supplied devices
+   * SetPowerStateByNodeList controls power for caller-supplied nodes
    * without requiring them to be registered in RMS inventory.
    */
-  rpc SetPowerStateByDeviceList(SetPowerStateByDeviceListRequest) returns (SetPowerStateByDeviceListResponse) {}
-  
+  rpc SetPowerStateByNodeList(SetPowerStateByNodeListRequest) returns (SetPowerStateByNodeListResponse) {}
+
   /*
    * GetPowerState retrieves the current power state of a node.
    * Returns the current state (ON, OFF, or UNKNOWN).
@@ -306,12 +305,12 @@ service RackManager {
   rpc GetPowerState(GetPowerStateRequest) returns (GetPowerStateResponse) {}
 
   /*
-   * GetPowerStateByDeviceList retrieves the current power state for caller-
-   * supplied devices without requiring them to be registered in RMS inventory.
-   * Returns per-device power state along with batch status.
+   * GetPowerStateByNodeList retrieves the current power state for caller-
+   * supplied nodes without requiring them to be registered in RMS inventory.
+   * Returns per-node power state along with batch status.
    */
-  rpc GetPowerStateByDeviceList(GetPowerStateByDeviceListRequest) returns (GetPowerStateByDeviceListResponse) {}
-  
+  rpc GetPowerStateByNodeList(GetPowerStateByNodeListRequest) returns (GetPowerStateByNodeListResponse) {}
+
   /*
    * SequenceRackPower controls the power state of all nodes in a rack.
    * Operations follow the configured power-on order for sequenced boot.
@@ -322,41 +321,41 @@ service RackManager {
   /*---------------------------------------------------------------------------
    * Inventory Control RPCs
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * GetAllInventory retrieves the complete inventory of all nodes across all racks.
    */
   rpc GetAllInventory(GetAllInventoryRequest) returns (GetAllInventoryResponse) {}
-  
+
   /*
    * AddNode registers one or more new nodes in the inventory.
    * Supports batch addition of multiple nodes in a single request.
    */
   rpc AddNode(AddNodeRequest) returns (AddNodeResponse) {}
-  
+
   /*
    * UpdateNode modifies the configuration of an existing node.
    * Only specified fields in the update_info will be changed.
    */
   rpc UpdateNode(UpdateNodeRequest) returns (UpdateNodeResponse) {}
-  
+
   /*
    * RemoveNode removes a node from the inventory. The node must exist in the specified rack.
   */
   rpc RemoveNode(RemoveNodeRequest) returns (RemoveNodeResponse) {}
-  
+
   /*
    * GetRackPowerOnSequence retrieves the configured boot sequence for a rack.
    */
   rpc GetRackPowerOnSequence(GetRackPowerOnSequenceRequest) returns (GetRackPowerOnSequenceResponse) {}
-  
+
   /*
    * SetRackPowerOnSequence configures the boot sequence for a rack.
    * Must be set before using RackPower operations.
    * Nodes boot in the specified order with optional completion verification.
    */
   rpc SetRackPowerOnSequence(SetRackPowerOnSequenceRequest) returns (SetRackPowerOnSequenceResponse) {}
-  
+
   /*
    * ListRacks returns a list of all rack IDs in the system.
   */
@@ -374,48 +373,48 @@ service RackManager {
   rpc GetDeviceInfoByNodeType(GetDeviceInfoByNodeTypeRequest) returns (GetDeviceInfoByNodeTypeResponse) {}
 
   /*
-   * GetDeviceInfoByDeviceList retrieves normalized device metadata for a caller-
-   * supplied list of devices. Each device is identified by its NewNodeInfo.
+   * GetDeviceInfoByNodeList retrieves normalized device metadata for a caller-
+   * supplied list of nodes. Each node is identified by its NodeInfo.
    */
-  rpc GetDeviceInfoByDeviceList(GetDeviceInfoByDeviceListRequest) returns (GetDeviceInfoByDeviceListResponse) {}
+  rpc GetDeviceInfoByNodeList(GetDeviceInfoByNodeListRequest) returns (GetDeviceInfoByNodeListResponse) {}
 
   /*---------------------------------------------------------------------------
    * Firmware Control RPCs
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * GetNodeFirmwareInventory retrieves all firmware component information for a node.
    * Returns version, update status, and health for each firmware component.
    */
   rpc GetNodeFirmwareInventory(GetNodeFirmwareInventoryRequest) returns (GetNodeFirmwareInventoryResponse) {}
-  
+
   /*
    * UpdateNodeFirmwareAsync initiates a firmware update on a specific node asynchronously.
    * Returns a job ID immediately. Use GetFirmwareJobStatus to track progress.
    * Works for all node types (compute, powershelf, switch).
    */
-  rpc UpdateNodeFirmwareAsync(UpdateNodeFirmwareRequest) returns (UpdateNodeFirmwareResponse) {}
+  rpc UpdateNodeFirmwareAsync(UpdateNodeFirmwareAsyncRequest) returns (UpdateNodeFirmwareAsyncResponse) {}
 
   /*
    * UpdateFirmwareByNodeTypeAsync initiates firmware updates on all nodes of a specific
    * type in a rack asynchronously. Returns a parent job ID for tracking overall batch status,
    * along with individual node job IDs. Use GetFirmwareJobStatus to track progress.
    */
-  rpc UpdateFirmwareByNodeTypeAsync(UpdateFirmwareByNodeTypeRequest) returns (UpdateFirmwareByNodeTypeAsyncResponse) {}
+  rpc UpdateFirmwareByNodeTypeAsync(UpdateFirmwareByNodeTypeAsyncRequest) returns (UpdateFirmwareByNodeTypeAsyncResponse) {}
 
   /*
-   * UpdateFirmwareByDeviceList initiates firmware updates on a specified list of devices
-   * asynchronously. Each device is identified by its NewNodeInfo. Separate firmware targets
-   * are provided for compute trays, switch trays, and power shelves — the appropriate target
-   * is applied to each device based on its node type.
+   * UpdateFirmwareByNodeList initiates firmware updates on a specified list of nodes
+   * asynchronously. Each node is identified by its NodeInfo. Separate firmware targets
+   * are provided for compute trays, switch trays, and power shelves, and the appropriate target
+   * is applied to each node based on its node type.
    * Returns a parent job ID for tracking overall batch status, along with individual node
    * job IDs. Use GetFirmwareJobStatus to track progress.
    */
-  rpc UpdateFirmwareByDeviceList(UpdateFirmwareByDeviceListRequest) returns (UpdateFirmwareByDeviceListResponse) {}
+  rpc UpdateFirmwareByNodeList(UpdateFirmwareByNodeListRequest) returns (UpdateFirmwareByNodeListResponse) {}
 
   /*
    * UpdateSwitchSystemImage initiates asynchronous switch system image updates on a caller-
-   * supplied list of switch devices. Each device is identified by its NewNodeInfo.
+   * supplied list of switch nodes. Each node is identified by its NodeInfo.
    * Returns a parent job ID for tracking overall batch status, along with individual
    * node job IDs. Use GetSwitchSystemImageJobStatus to track progress.
    */
@@ -457,28 +456,28 @@ service RackManager {
   rpc SetDefaultFirmwareObject(SetDefaultFirmwareObjectRequest) returns (FirmwareObject) {}
 
   /*
-   * ApplyFirmwareObject resolves stored firmware targets and starts firmware updates for supplied devices.
+   * ApplyFirmwareObject resolves stored firmware targets and starts firmware updates for supplied nodes.
    */
   rpc ApplyFirmwareObject(ApplyFirmwareObjectRequest) returns (ApplyFirmwareObjectResponse) {}
 
   /*
-   * ApplyFirmwareObjectFromJSON ingests a firmware object from JSON, downloads required
-   * artifacts, resolves firmware targets, and starts firmware updates for supplied devices.
+   * ApplyFirmwareObjectFromJson ingests a firmware object from JSON, downloads required
+   * artifacts, resolves firmware targets, and starts firmware updates for supplied nodes.
    *
    * RMS treats the ingested firmware object as ephemeral for this request. It uses
    * access_token only for artifact download and does not persist the token or object.
    */
-  rpc ApplyFirmwareObjectFromJSON(ApplyFirmwareObjectFromJsonRequest) returns (ApplyFirmwareObjectResponse) {}
+  rpc ApplyFirmwareObjectFromJson(ApplyFirmwareObjectFromJsonRequest) returns (ApplyFirmwareObjectFromJsonResponse) {}
 
   /*
-   * ApplySwitchSystemImageFromJSON ingests a firmware object from SOT JSON, downloads
+   * ApplySwitchSystemImageFromJson ingests a firmware object from SOT JSON, downloads
    * required artifacts, resolves the stored switch system image, and starts updates for
    * supplied switches.
    *
    * RMS treats the ingested firmware object as ephemeral for this request. It uses
    * access_token only for artifact download and does not persist the token or object.
    */
-  rpc ApplySwitchSystemImageFromJSON(ApplySwitchSystemImageFromJsonRequest) returns (ApplySwitchSystemImageResponse) {}
+  rpc ApplySwitchSystemImageFromJson(ApplySwitchSystemImageFromJsonRequest) returns (ApplySwitchSystemImageFromJsonResponse) {}
 
   /*
    * ApplySwitchSystemImage resolves a stored switch system image and starts updates for supplied switches.
@@ -493,15 +492,15 @@ service RackManager {
 
   /*
    * ListFirmwareOnSwitch lists the firmware for switch.
-   * Returns version, update status, and health for switch firmware component. 
+   * Returns version, update status, and health for switch firmware component.
    */
-   rpc ListFirmwareOnSwitch(ListFirmwareOnSwitchCommand) returns (ListFirmwareOnSwitchResponse) {}
+   rpc ListFirmwareOnSwitch(ListFirmwareOnSwitchRequest) returns (ListFirmwareOnSwitchResponse) {}
 
    /*
    * PushFirmwareToSwitch Push a firmware binary to target Switch
-   * Returns success or error_message 
+   * Returns success or error_message
    */
-   rpc PushFirmwareToSwitch(PushFirmwareToSwitchCommand) returns (PushFirmwareToSwitchResponse) {}
+   rpc PushFirmwareToSwitch(PushFirmwareToSwitchRequest) returns (PushFirmwareToSwitchResponse) {}
 
    /*
     * UpgradeFirmwareOnSwitch performs a complete firmware upgrade workflow for a switch component.
@@ -509,12 +508,12 @@ service RackManager {
     * power cycling the switch, waiting for health, and verifying the new version.
     * Returns the stage where upgrade failed (if any) along with error details.
     */
-   rpc UpgradeFirmwareOnSwitch(UpgradeFirmwareOnSwitchCommand) returns (UpgradeFirmwareOnSwitchResponse) {}
+   rpc UpgradeFirmwareOnSwitch(UpgradeFirmwareOnSwitchRequest) returns (UpgradeFirmwareOnSwitchResponse) {}
 
   /*---------------------------------------------------------------------------
    * Scale Up switch control RPCs
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * ConfigureScaleUpFabricManager performs complete ScaleUpFabricManager configuration on a switch.
    * This includes enabling the scale fabric services services,configuring gRPC access,and sets
@@ -551,19 +550,19 @@ service RackManager {
    * Switch Control RPCs
    * Credentials are resolved from the node's stored inventory data.
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * FetchSwitchSystemImage downloads a switch OS image from a remote URL to the switch.
    * Returns a job ID for tracking the download progress.
    */
   rpc FetchSwitchSystemImage(FetchSwitchSystemImageRequest) returns (FetchSwitchSystemImageResponse) {}
-  
+
   /*
    * InstallSwitchSystemImage installs a previously fetched OS image on the switch.
    * Returns a job ID for tracking the installation progress.
    */
   rpc InstallSwitchSystemImage(InstallSwitchSystemImageRequest) returns (InstallSwitchSystemImageResponse) {}
-  
+
   /*
    * ListSwitchSystemImages retrieves the list of OS images available on the switch.
    * Returns information about installed and staged images.
@@ -578,7 +577,7 @@ service RackManager {
 
   /*
    * UpdateSwitchSystemPassword updates the OS-level password for a specific user
-   * on a caller-supplied list of switch devices. Credentials are resolved from
+   * on a caller-supplied list of switch nodes. Credentials are resolved from
    * the node's stored inventory data.
    */
   rpc UpdateSwitchSystemPassword(UpdateSwitchSystemPasswordRequest) returns (UpdateSwitchSystemPasswordResponse) {}
@@ -586,17 +585,16 @@ service RackManager {
   /*---------------------------------------------------------------------------
    * Utility RPCs
    *-------------------------------------------------------------------------*/
-  
+
   /*
    * Version returns server version information.
-   * Currently returns empty response; version info may be added in future releases.
    */
-  rpc Version(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  rpc Version(VersionRequest) returns (VersionResponse) {}
 
   /*
    * PollJobStatus poll given job id in an interval.
    */
-   rpc PollJobStatus(PollJobStatusCommand) returns (PollJobStatusResponse) {}
+   rpc PollJobStatus(PollJobStatusRequest) returns (PollJobStatusResponse) {}
 
   /*
    * GetFirmwareJobStatus retrieves the current status of an asynchronous firmware job.
@@ -613,7 +611,8 @@ service RackManager {
 
 // SetPowerStateRequest controls the power state of a single node.
 message SetPowerStateRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;           // Target node identifier
   PowerOperation operation = 3; // Power operation to perform
   string rack_id = 4;           // Rack containing the target node
@@ -621,33 +620,37 @@ message SetPowerStateRequest {
 
 // SetPowerStateResponse confirms the power operation result.
 message SetPowerStateResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;   // SUCCESS if power operation completed, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;   // RETURN_CODE_SUCCESS if power operation completed, RETURN_CODE_FAILURE otherwise
 }
 
-// SetPowerStateByDeviceListRequest controls power for unregistered devices.
-message SetPowerStateByDeviceListRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;             // Caller-supplied device connection details
+// SetPowerStateByNodeListRequest controls power for unregistered nodes.
+message SetPowerStateByNodeListRequest {
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;             // Caller-supplied node connection details
   PowerOperation operation = 3;  // Power operation to perform
 }
 
-// SetPowerStateByDeviceListResponse reports per-device power operation results.
-message SetPowerStateByDeviceListResponse {
+// SetPowerStateByNodeListResponse reports per-node power operation results.
+message SetPowerStateByNodeListResponse {
   NodeBatchResponse response = 1;
 }
 
 // GetPowerStateRequest queries the current power state of a node.
 message GetPowerStateRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;     // Target node identifier
   string rack_id = 3;     // Rack containing the target node
 }
 
 // GetPowerStateResponse returns the current power state of a node.
 message GetPowerStateResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;   // SUCCESS if query completed, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;   // RETURN_CODE_SUCCESS if query completed, RETURN_CODE_FAILURE otherwise
   string node_id = 3;      // Node identifier (echoed from request)
   string pstate = 4;       // Current power state: "ON", "OFF", or "UNKNOWN"
   string rack_id = 5;      // Rack identifier (echoed from request)
@@ -659,32 +662,34 @@ message NodePowerState {
   string pstate = 2;   // Current power state: "ON", "OFF", or "UNKNOWN"
 }
 
-// GetPowerStateByDeviceListRequest queries power state for unregistered devices.
-message GetPowerStateByDeviceListRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;  // Caller-supplied device connection details
+// GetPowerStateByNodeListRequest queries power state for unregistered nodes.
+message GetPowerStateByNodeListRequest {
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;  // Caller-supplied node connection details
 }
 
-// GetPowerStateByDeviceListResponse reports per-device power state results.
-message GetPowerStateByDeviceListResponse {
+// GetPowerStateByNodeListResponse reports per-node power state results.
+message GetPowerStateByNodeListResponse {
   NodeBatchResponse response = 1;
-  repeated NodePowerState node_power_states = 2;  // Power state for each successfully queried device
+  repeated NodePowerState node_power_states = 2;  // Power state for each successfully queried node
 }
 
 // RackPowerRequest controls power for all nodes in a rack.
 message SequenceRackPowerRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   RackPowerOperation operation = 2; // Rack-wide power operation to perform
   string rack_id = 3;               // Target rack identifier
 }
 
-// RackPowerResponse confirms the rack power operation result.
+// SequenceRackPowerResponse confirms the rack power operation result.
 message SequenceRackPowerResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;   // SUCCESS if operation completed, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;   // RETURN_CODE_SUCCESS if operation completed, RETURN_CODE_FAILURE otherwise
   string message = 3;      // Human-readable status or error message
 }
-
 
 /*******************************************************************************
  * INVENTORY CONTROL MESSAGES
@@ -692,20 +697,22 @@ message SequenceRackPowerResponse {
 
 // GetInventoryRequest retrieves the complete system inventory.
 message GetAllInventoryRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
 }
 
 // GetInventoryResponse returns all nodes and their components.
 message GetAllInventoryResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                // SUCCESS if inventory retrieved, FAILURE otherwise
+  reserved 1, 2;
+  reserved "metadata", "status";
   repeated NodeInventoryInfo nodes = 3; // Complete list of nodes across all racks
 }
 
 // AddNodeRequest registers new nodes in the inventory.
 message AddNodeRequest {
-  Metadata metadata = 1;
-  repeated NewNodeInfo node_info = 2; // List of nodes to add (batch operation supported)
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2; // List of nodes to add (batch operation supported)
 }
 
 // AddNodeResponse reports the results of adding nodes.
@@ -715,7 +722,8 @@ message AddNodeResponse {
 
 // UpdateNodeRequest modifies an existing node's configuration.
 message UpdateNodeRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;             // Target node identifier
   NodeUpdateInfo update_info = 3; // Fields to update (only set fields are changed)
   string rack_id = 4;             // Rack containing the target node
@@ -728,7 +736,8 @@ message UpdateNodeResponse {
 
 // RemoveNodeRequest deletes a node from the inventory.
 message RemoveNodeRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;     // Target node identifier to remove
   string rack_id = 3;     // Rack containing the target node
 }
@@ -740,21 +749,24 @@ message RemoveNodeResponse {
 
 // GetPowerOnOrderRequest retrieves the boot sequence for a rack.
 message GetRackPowerOnSequenceRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;     // Target rack identifier
 }
 
 // GetPowerOnOrderResponse returns the configured boot sequence.
 message GetRackPowerOnSequenceResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                        // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                        // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated PowerOnOrderItem power_on_order = 3; // Ordered list of nodes for boot sequence
   bool is_valid = 4;                            // Whether the power-on order is valid for use
 }
 
 // SetPowerOnOrderRequest configures the boot sequence for a rack.
 message SetRackPowerOnSequenceRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   repeated PowerOnOrderItem power_on_order = 2; // Ordered list of nodes for boot sequence
   string rack_id = 3;                           // Target rack identifier
 }
@@ -766,56 +778,63 @@ message SetRackPowerOnSequenceResponse {
 
 // ListRacksRequest retrieves all rack identifiers.
 message ListRacksRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
 }
 
 // ListRacksResponse returns all rack identifiers in the system.
 message ListRacksResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;        // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1, 2;
+  reserved "metadata", "status";
   repeated string rack_ids = 3; // List of all rack identifiers
 }
 
 // GetNodeDeviceInfoRequest retrieves normalized device metadata for a specific node.
 message GetNodeDeviceInfoRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;     // Rack containing the target node
   string node_id = 3;     // Target node identifier
 }
 
 // GetNodeDeviceInfoResponse returns normalized device metadata for a specific node.
 message GetNodeDeviceInfoResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;      // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;      // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string message = 3;         // Human-readable status or error message
   NodeDeviceInfo device_info = 4; // Normalized device metadata for the node
 }
 
 // GetDeviceInfoByNodeTypeRequest retrieves device metadata for all nodes of a type in a rack.
 message GetDeviceInfoByNodeTypeRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;     // Target rack identifier
   NodeType node_type = 3; // Type of nodes to query
 }
 
 // GetDeviceInfoByNodeTypeResponse returns device metadata for all matching nodes in a rack.
 message GetDeviceInfoByNodeTypeResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                   // SUCCESS if retrieved, FAILURE otherwise
-  string message = 3;                      // Human-readable status or error message
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                      // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
+  string message = 3;                         // Human-readable status or error message
   repeated NodeDeviceInfo node_device_info = 4; // Device metadata grouped by node
 }
 
-// GetDeviceInfoByDeviceListRequest retrieves device metadata for a specified list of devices.
-message GetDeviceInfoByDeviceListRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;  // Devices to query
+// GetDeviceInfoByNodeListRequest retrieves device metadata for a specified list of nodes.
+message GetDeviceInfoByNodeListRequest {
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;  // Nodes to query
 }
 
-// GetDeviceInfoByDeviceListResponse returns device metadata for the requested devices.
-message GetDeviceInfoByDeviceListResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                      // SUCCESS if all requested nodes succeeded, FAILURE otherwise
+// GetDeviceInfoByNodeListResponse returns device metadata for the requested nodes.
+message GetDeviceInfoByNodeListResponse {
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                      // RETURN_CODE_SUCCESS if all requested nodes succeeded, RETURN_CODE_FAILURE otherwise
   string message = 3;                         // Batch summary; includes per-node failure details when any node fails
   repeated NodeDeviceInfo node_device_info = 4; // Successful device info results
 }
@@ -827,15 +846,17 @@ message GetDeviceInfoByDeviceListResponse {
 
 // GetNodeFirmwareInventoryRequest retrieves firmware info for a specific node.
 message GetNodeFirmwareInventoryRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;     // Target node identifier
   string rack_id = 3;     // Rack containing the target node
 }
 
 // GetNodeFirmwareInventoryResponse returns firmware component information.
 message GetNodeFirmwareInventoryResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                            // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                            // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated FirmwareInventoryInfo firmware_list = 3; // List of firmware components on the node
 }
 
@@ -855,11 +876,12 @@ message FirmwareObjectComponentFilter {
   repeated string components = 1; // Optional component filter for one node type
 }
 
-// UpdateFirmwareRequest initiates a firmware update on a node.
+// UpdateNodeFirmwareAsyncRequest initiates a firmware update on a node.
 // Supports single target (filename + target fields) or multiple targets (firmware_targets list).
 // If firmware_targets is non-empty, it takes precedence over the single filename/target fields.
-message UpdateNodeFirmwareRequest {
-  Metadata metadata = 1;
+message UpdateNodeFirmwareAsyncRequest {
+  reserved 1;
+  reserved "metadata";
   string node_id = 2;     // Target node identifier
   string filename = 3;    // Single firmware filename (used when firmware_targets is empty)
   string target = 4;      // Single Redfish target URI (used when firmware_targets is empty)
@@ -869,20 +891,22 @@ message UpdateNodeFirmwareRequest {
   bool force_update = 8;  // Force the BMC to accept the firmware even if it's a downgrade
 }
 
-// UpdateFirmwareResponse reports the firmware update result.
-message UpdateNodeFirmwareResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;              // SUCCESS if update completed, FAILURE otherwise
+// UpdateNodeFirmwareAsyncResponse reports the firmware update result.
+message UpdateNodeFirmwareAsyncResponse {
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;              // RETURN_CODE_SUCCESS if update completed, RETURN_CODE_FAILURE otherwise
   string message = 3;                 // Human-readable status or error message
   FirmwareUpdateError error_code = 4; // Detailed error code for troubleshooting
   string job_id = 5; // Job ID for async operations (use with GetFirmwareJobStatus to track progress)
 }
 
-// UpdateFirmwareByNodeTypeRequest updates firmware on all nodes of a type.
+// UpdateFirmwareByNodeTypeAsyncRequest updates firmware on all nodes of a type.
 // Supports single target (filename + target fields) or multiple targets (firmware_targets list).
 // If firmware_targets is non-empty, it takes precedence over the single filename/target fields.
-message UpdateFirmwareByNodeTypeRequest {
-  Metadata metadata = 1;
+message UpdateFirmwareByNodeTypeAsyncRequest {
+  reserved 1;
+  reserved "metadata";
   NodeType node_type = 2; // Type of nodes to update
   string filename = 3;    // Single firmware filename (used when firmware_targets is empty)
   string target = 4;      // Single Redfish target URI (used when firmware_targets is empty)
@@ -895,35 +919,36 @@ message UpdateFirmwareByNodeTypeRequest {
 // NodeFirmwareJobInfo pairs a node ID with its async firmware job ID.
 message NodeFirmwareJobInfo {
   string node_id = 1;  // Node identifier
-  string job_id = 2;   // Firmware job ID (use with GetFirmwareJobStatus to track progress)
+  string job_id = 2;   // Firmware job ID returned for this node
 }
 
 // UpdateFirmwareByNodeTypeAsyncResponse reports the created async jobs.
 message UpdateFirmwareByNodeTypeAsyncResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                            // SUCCESS if jobs created, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                            // RETURN_CODE_SUCCESS if jobs created, RETURN_CODE_FAILURE otherwise
   string message = 3;                               // Human-readable summary message
   string job_id = 4;                                // Parent job ID for the overall batch (use with GetFirmwareJobStatus)
-  int32 total_nodes = 5;                            // Total number of nodes targeted
-  repeated NodeFirmwareJobInfo node_jobs = 6;       // Individual job ID per node
+  uint32 total_nodes = 5;                           // Total number of nodes targeted
+  repeated NodeFirmwareJobInfo jobs = 6;            // Individual job ID per node
 }
 
-// UpdateFirmwareByDeviceListRequest initiates firmware updates on a specified list of devices.
-// Firmware targets are provided per node type via a map keyed by NodeType enum value
-// (e.g., NODE_TYPE_COMPUTE=1, NODE_TYPE_POWERSHELF=2, NODE_TYPE_SWITCH=3).
-// The appropriate firmware targets are applied to each device based on its node type.
-message UpdateFirmwareByDeviceListRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;                                          // Devices to update
-  map<int32, FirmwareTargetList> firmware_targets = 3;        // Firmware targets keyed by NodeType
-  bool activate = 4;                                          // Whether to activate firmware after installation
-  bool force_update = 5;                                      // Force the BMC to accept the firmware even if it's a downgrade
+// UpdateFirmwareByNodeListRequest initiates firmware updates on a specified list of nodes.
+// Firmware targets are provided per node type.
+// The appropriate firmware targets are applied to each node based on its node type.
+message UpdateFirmwareByNodeListRequest {
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;                                   // Nodes to update
+  map<int32, FirmwareTargetList> firmware_targets = 3; // Firmware targets keyed by NodeType enum value
+  bool activate = 4;                                   // Whether to activate firmware after installation
+  bool force_update = 5;                               // Force the BMC to accept the firmware even if it's a downgrade
 }
 
-// UpdateFirmwareByDeviceListResponse reports firmware update results.
-message UpdateFirmwareByDeviceListResponse {
+// UpdateFirmwareByNodeListResponse reports firmware update results.
+message UpdateFirmwareByNodeListResponse {
   NodeBatchResponse response = 1;
-  repeated NodeFirmwareJobInfo node_jobs = 2;       // Individual job ID per node
+  repeated NodeFirmwareJobInfo jobs = 2; // Individual job ID per node
 }
 
 // SwitchSystemImageUpdateJobInfo pairs a switch node ID with its async system image job ID.
@@ -934,28 +959,31 @@ message SwitchSystemImageUpdateJobInfo {
 
 // UpdateSwitchSystemImageRequest initiates switch system image updates on a specified list of switches.
 message UpdateSwitchSystemImageRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;            // Switch devices to update
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;            // Switch nodes to update
   string image_filename = 3;    // Binary filename as it should exist on the switch
-  string local_file_path = 4;   // Local file path on the target switch
+  string local_file_path = 4;   // Local file path on the RMS host
 }
 
 // UpdateSwitchSystemImageResponse reports switch system image update job creation results.
 message UpdateSwitchSystemImageResponse {
   NodeBatchResponse response = 1;
-  repeated SwitchSystemImageUpdateJobInfo node_jobs = 2; // Individual job ID per switch
+  repeated SwitchSystemImageUpdateJobInfo jobs = 2; // Individual job ID per switch
 }
 
 // GetRackFirmwareInventoryRequest retrieves firmware for all nodes in a rack.
 message GetRackFirmwareInventoryRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;     // Target rack identifier
 }
 
 // GetRackFirmwareInventoryResponse returns firmware info for all nodes.
 message GetRackFirmwareInventoryResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                    // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   repeated NodeFirmwareInventory nodes = 3; // Firmware inventory grouped by node
 }
 
@@ -990,7 +1018,7 @@ message FirmwareObjectDeviceComponents {
 message FirmwareObjectComponent {
   string name = 1;           // Normalized component name accepted by ApplyFirmwareObject
   string version = 2;
-  string bundle = 3;         
+  string bundle = 3;
   string source_component = 4; // Raw component label from the firmware object
   repeated FirmwareObjectSubcomponent subcomponents = 5;
   repeated FirmwareObjectArtifact artifacts = 6;
@@ -1021,7 +1049,8 @@ message FirmwareObjectSwitchSystemImage {
 
 // AddFirmwareObjectRequest adds firmware object config and authorizes RMS artifact download.
 message AddFirmwareObjectRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string config_json = 2;
   // Used only for immediate/background artifact download; RMS does not persist this token.
   string access_token = 3;
@@ -1031,12 +1060,14 @@ message AddFirmwareObjectRequest {
 }
 
 message GetFirmwareObjectRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string id = 2;
 }
 
 message ListFirmwareObjectsRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   bool only_available = 2;
   string hardware_type = 3;
 }
@@ -1046,24 +1077,27 @@ message ListFirmwareObjectsResponse {
 }
 
 message DeleteFirmwareObjectRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string id = 2;
 }
 
 message SetDefaultFirmwareObjectRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   // Default scope is determined by the hardware_type stored on this object.
   string object_id = 2;
 }
 
 message ApplyFirmwareObjectRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;
   string object_id = 3;          // Empty means use default for hardware_type
   string firmware_type = 4;        // "dev" or "prod"
   string hardware_type = 5;
-  repeated string components = 6;  // Deprecated: global component filter for all node types
-  NodeSet nodes = 7;               // Caller-supplied devices
+  repeated string components = 6 [deprecated = true]; // Deprecated: global component filter for all node types
+  NodeSet nodes = 7;               // Caller-supplied nodes
   bool force_update = 8;
   // Component filters keyed by NodeType. If non-empty, only listed node types are updated.
   // A listed node type with an empty components list means all components for that node type.
@@ -1073,51 +1107,68 @@ message ApplyFirmwareObjectRequest {
 message ApplyFirmwareObjectResponse {
   NodeBatchResponse response = 1;          // response.job_id is parent job id
   string object_id = 2;
-  repeated NodeFirmwareJobInfo node_jobs = 3;
+  repeated NodeFirmwareJobInfo jobs = 3;
 }
 
 message ApplyFirmwareObjectFromJsonRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;
   string config_json = 3;         // SOT JSON containing the firmware object ID and artifacts
   string access_token = 4;        // Used only for artifact download; RMS does not persist it
   string firmware_type = 5;       // "dev" or "prod"
   string hardware_type = 6;
-  NodeSet nodes = 7;              // Caller-supplied devices
+  NodeSet nodes = 7;              // Caller-supplied nodes
   bool force_update = 8;
   // Component filters keyed by NodeType. If non-empty, only listed node types are updated.
   // A listed node type with an empty components list means all components for that node type.
   map<int32, FirmwareObjectComponentFilter> component_filters = 9;
 }
 
+message ApplyFirmwareObjectFromJsonResponse {
+  NodeBatchResponse response = 1;          // response.job_id is parent job id
+  string object_id = 2;
+  repeated NodeFirmwareJobInfo jobs = 3;
+}
+
 message ApplySwitchSystemImageRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;
   string object_id = 3;    // Empty means use default for hardware_type
   string software_type = 4; // "dev" or "prod"
   string hardware_type = 5;
-  NodeSet nodes = 6;         // Caller-supplied switch devices
+  NodeSet nodes = 6;         // Caller-supplied switch nodes
 }
 
 message ApplySwitchSystemImageResponse {
   NodeBatchResponse response = 1;                       // response.job_id is parent job id
   string object_id = 2;
   string image_filename = 3;
-  repeated SwitchSystemImageUpdateJobInfo node_jobs = 4;
+  repeated SwitchSystemImageUpdateJobInfo jobs = 4;
 }
 
 message ApplySwitchSystemImageFromJsonRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;
   string config_json = 3;       // SOT JSON containing the firmware object ID and switch image
   string access_token = 4;      // Used only for artifact download; RMS does not persist it
   string software_type = 5;     // "dev" or "prod"
   string hardware_type = 6;
-  NodeSet nodes = 7;            // Caller-supplied switch devices
+  NodeSet nodes = 7;            // Caller-supplied switch nodes
+}
+
+message ApplySwitchSystemImageFromJsonResponse {
+  NodeBatchResponse response = 1;                       // response.job_id is parent job id
+  string object_id = 2;
+  string image_filename = 3;
+  repeated SwitchSystemImageUpdateJobInfo jobs = 4;
 }
 
 message GetFirmwareObjectHistoryRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string object_id = 2;       // Empty means no object filter
   repeated string rack_ids = 3; // Empty means all racks
 }
@@ -1145,19 +1196,21 @@ message FirmwareObjectHistoryRecord {
  * This operation enables the ScaleUpFabricManager, configures ScaleUpFabricManager access, and sets topology.
  */
 message ConfigureScaleUpFabricManagerRequest {
-  Metadata metadata = 1;
-  NewNodeInfo device = 2;      // Target switch identity and direct connection information
+  reserved 1;
+  reserved "metadata";
+  NodeInfo node = 2;        // Target switch identity and direct connection information
   string topology_type = 3;    // Topology to be set for ScaleUpFabric
   bool verify_ssl = 4;         // Whether to verify SSL certificates for HTTPS connections
 }
 
 // ConfigureScaleUpFabricManagerResponse reports the ScaleUpFabricManager  configuration result.
 message ConfigureScaleUpFabricManagerResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;      // SUCCESS if configuration completed, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;      // RETURN_CODE_SUCCESS if configuration completed, RETURN_CODE_FAILURE otherwise
   string message = 3;         // Human-readable status or error message
   string topology_used = 4;   // multi-node scaleup topology that was applied
-  bool ScaleUpFabricState_enabled = 5;   // Whether the ScaleUpFabricState State is now enabled
+  bool scale_up_fabric_state_enabled = 5; // Whether the ScaleUpFabricState State is now enabled
   bool grpc_enabled = 6;      // Whether gRPC access is now enabled
 }
 
@@ -1166,8 +1219,9 @@ message ConfigureScaleUpFabricManagerResponse {
  * and config save across caller-supplied switches.
  */
 message SetScaleUpFabricStateRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;       // Switch devices to update
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;       // Switch nodes to update
   optional bool enabled = 3;  // true = enabled, false = disabled
   bool verify_ssl = 4;     // Whether to verify SSL certificates for HTTPS connections
 }
@@ -1185,33 +1239,36 @@ message ScaleUpFabricServiceStatusEntry {
 
 // GetScaleUpFabricServicesStatusRequest checks cluster health and nmx-controller status on caller-supplied switches.
 message GetScaleUpFabricServicesStatusRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;      // Switch devices to query
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;      // Switch nodes to query
   bool verify_ssl = 3;    // Whether to verify SSL certificates for HTTPS connections
 }
 
 // GetScaleUpFabricServicesStatusResponse reports per-switch results keyed by node_id.
 message GetScaleUpFabricServicesStatusResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   map<string, ScaleUpFabricServiceStatusEntry> device_info_result = 3; // key = node_id
 }
 
 // GetScaleUpFabricStateRequest retrieves the ScaleUpFabric state for a single switch.
 message GetScaleUpFabricStateRequest {
-  Metadata metadata = 1;
-  NewNodeInfo device = 2;   // Target switch identity and direct connection information
+  reserved 1;
+  reserved "metadata";
+  NodeInfo node = 2;     // Target switch identity and direct connection information
   bool verify_ssl = 3;      // Whether to verify SSL certificates
 }
 
 // GetScaleUpFabricStateResponse returns the ScaleUpFabric state.
 message GetScaleUpFabricStateResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string state_json = 3;    // JSON object containing ScaleUpFabric state information
   string error_message = 4; // Error details if query failed
 }
-
 
 /*******************************************************************************
  * SWITCH CONTROL MESSAGES
@@ -1222,92 +1279,95 @@ message GetScaleUpFabricStateResponse {
 
 // FetchSwitchSystemImageRequest downloads an OS image to a switch.
 message FetchSwitchSystemImageRequest {
-  Metadata metadata = 1;
-  string rack_id = 2;      // Rack containing the target switch (required)
-  string node_id = 3;      // Target switch node identifier (required)
-  int32 port = 4;          // API port number (default: 443)
-  bool verify_ssl = 5;     // Whether to verify SSL certificates
+  reserved 1, 4, 5;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;      // Rack containing the target switch
+  string node_id = 3;      // Target switch node identifier
   string remote_url = 6;   // URL to download the system image from
 }
 
 // FetchSwitchSystemImageResponse reports the download initiation result.
 message FetchSwitchSystemImageResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if download started, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if download started, RETURN_CODE_FAILURE otherwise
   string job_id = 3;        // Job identifier for tracking download progress
   string error_message = 4; // Error details if download failed to start
 }
 
 // InstallSwitchSystemImageRequest installs an OS image on a switch.
 message InstallSwitchSystemImageRequest {
-  Metadata metadata = 1;
-  string rack_id = 2;         // Rack containing the target switch (required)
-  string node_id = 3;         // Target switch node identifier (required)
-  int32 port = 4;             // API port number (default: 443)
-  bool verify_ssl = 5;        // Whether to verify SSL certificates
+  reserved 1, 4, 5;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;         // Rack containing the target switch
+  string node_id = 3;         // Target switch node identifier
   string image_filename = 6;  // Filename of the image to install (must be fetched first)
 }
 
 // InstallSwitchSystemImageResponse reports the installation initiation result.
 message InstallSwitchSystemImageResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if installation started, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if installation started, RETURN_CODE_FAILURE otherwise
   string job_id = 3;        // Job identifier for tracking installation progress
   string error_message = 4; // Error details if installation failed to start
 }
 
 // ListSwitchSystemImagesRequest retrieves available OS images on a switch.
 message ListSwitchSystemImagesRequest {
-  Metadata metadata = 1;
-  string rack_id = 2;     // Rack containing the target switch (required)
-  string node_id = 3;     // Target switch node identifier (required)
-  int32 port = 4;         // API port number (default: 443)
-  bool verify_ssl = 5;    // Whether to verify SSL certificates
+  reserved 1, 4, 5;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;      // Rack containing the target switch
+  string node_id = 3;      // Target switch node identifier
 }
 
 // ListSwitchSystemImagesResponse returns available OS images.
 message ListSwitchSystemImagesResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if retrieved, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if retrieved, RETURN_CODE_FAILURE otherwise
   string images_json = 3;   // JSON array containing image information
   string error_message = 4; // Error details if query failed
 }
 
 // EnableScaleUpFabricTelemetryInterfaceRequest enables or disables the FabricTelemetryInterface.
 message EnableScaleUpFabricTelemetryInterfaceRequest {
-  Metadata metadata = 1;
-  NewNodeInfo device = 2; // Target switch identity and direct connection information
+  reserved 1;
+  reserved "metadata";
+  NodeInfo node = 2;      // Target switch identity and direct connection information
   bool enable = 3;        // true to enable ScaleUpFabricTelemetryInterface, false to disable
   bool verify_ssl = 4;    // Whether to verify SSL certificates
 }
 
 // EnableScaleUpFabricTelemetryInterfaceResponse reports the FabricTelemetryInterface status.
 message EnableScaleUpFabricTelemetryInterfaceResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if configured, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
   string result_json = 3;   // JSON object containing configuration result
   string error_message = 4; // Error details if configuration failed
 }
 
-message ListFirmwareOnSwitchCommand {
-  Metadata metadata = 1;
-  string rack_id = 2;                              // Required: Rack ID for inventory lookup
-  string node_id = 3;                              // Required: Node ID for inventory lookup
+message ListFirmwareOnSwitchRequest {
+  reserved 1, 5, 6;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;                              // Rack ID for inventory lookup
+  string node_id = 3;                              // Node ID for inventory lookup
   SwitchFirmwareComponentType component_type = 4;  // Required: Firmware component type enum
-  int32 port = 5;                                  // Optional: API port (default: 443)
-  bool verify_ssl = 6;                             // Optional: Whether to verify SSL certificates
 }
 
 message ListFirmwareOnSwitchResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;    // SUCCESS if configured, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
   string result_json = 3;   // JSON object containing configuration result
   string error_message = 4; // Error details if configuration failed
 }
 
-// PushFirmwareToSwitch command/response
-message PushFirmwareToSwitchCommand {
-  Metadata metadata = 1;
+// PushFirmwareToSwitch request/response
+message PushFirmwareToSwitchRequest {
+  reserved 1;
+  reserved "metadata";
   string rack_id = 2;                              // Required: Rack ID for inventory lookup
   string node_id = 3;                              // Required: Node ID for inventory lookup
   SwitchFirmwareComponentType component_type = 4;  // Required: Firmware component type enum
@@ -1316,49 +1376,49 @@ message PushFirmwareToSwitchCommand {
 }
 
 message PushFirmwareToSwitchResponse {
-  Metadata metadata = 1;    
-  ReturnCode status = 2;    // SUCCESS if configured, FAILURE otherwise
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
   string result_json = 3;   // JSON object containing configuration result
   string error_message = 4; // Error details if configuration failed
 }
 
-// UpgradeFirmwareOnSwitchCommand performs complete firmware upgrade workflow for a switch component.
-// If node_id is empty, upgrades all switches in the rack in parallel.
-message UpgradeFirmwareOnSwitchCommand {
-  Metadata metadata = 1;
-  string rack_id = 2;                                    // Required: Rack ID for inventory lookup
-  optional string node_id = 3;                           // Optional: Node ID. If empty, upgrades all switches in rack
+// UpgradeFirmwareOnSwitchRequest performs complete firmware upgrade workflow for a switch component.
+message UpgradeFirmwareOnSwitchRequest {
+  reserved 1, 6, 7;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;                               // Rack ID for inventory lookup
+  string node_id = 3;                               // Node ID for inventory lookup
   SwitchFirmwareComponentType component = 4;             // Required: Firmware component type enum
   string filename = 5;                                   // Required: Local filesystem path to firmware file
-  int32 port = 6;                                        // Optional: API port (default: 443)
-  bool verify_ssl = 7;                                   // Optional: Whether to verify SSL certificates
 }
 
 message UpgradeFirmwareOnSwitchResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                                // SUCCESS if upgrade completed, FAILURE otherwise
-  UpgradeStage failed_stage = 3;                         // Stage where upgrade failed (if status is FAILURE)
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                                // RETURN_CODE_SUCCESS if upgrade completed, RETURN_CODE_FAILURE otherwise
+  UpgradeStage failed_stage = 3;                         // Stage where upgrade failed (if status is RETURN_CODE_FAILURE)
   string error_message = 4;                             // Error details if upgrade failed (or summary message for multi-switch mode)
   string current_filename = 5;                          // Firmware filename before upgrade (single switch mode only)
   string new_filename = 6;                              // Firmware filename after upgrade (if successful, single switch mode only)
   string result_json = 7;                               // JSON array with detailed results for all switches (multi-switch mode only)
 }
 
-message PollJobStatusCommand {
-  Metadata metadata = 1;
-  string rack_id = 2;               // Required: Rack ID for inventory lookup
-  string node_id = 3;               // Required: Node ID for inventory lookup
+message PollJobStatusRequest {
+  reserved 1, 5, 6;
+  reserved "metadata", "port", "verify_ssl";
+  string rack_id = 2;               // Rack ID for inventory lookup
+  string node_id = 3;               // Node ID for inventory lookup
   string job_id = 4;                // Job id for previously submitted job
-  int32 port = 5;                   // Optional: API port (default: 443)
-  bool verify_ssl = 6;              // Optional: Whether to verify SSL certificates
-  int32 timeout_seconds = 7;        // Optional: Timeout for the polling job
-  int32 poll_interval_seconds = 8;  // Optional: Poll interval in seconds (default: 5)
+  uint32 timeout_seconds = 7;       // Optional: Timeout for the polling job
+  uint32 poll_interval_seconds = 8; // Optional: Poll interval in seconds (default: 5)
 }
 
 message PollJobStatusResponse {
-  Metadata metadata = 1;   
-  ReturnCode status = 2;    // SUCCESS if configured, FAILURE otherwise
-  string state = 3;        // State of the job (active,pending,running)   
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;    // RETURN_CODE_SUCCESS if configured, RETURN_CODE_FAILURE otherwise
+  string state = 3;        // State of the job (active,pending,running)
   string result_json = 4; // JSON object containing configuration result
   string error_message = 5; // Error details if configuration failed
 }
@@ -1367,10 +1427,11 @@ message PollJobStatusResponse {
  * SWITCH PASSWORD CONTROL MESSAGES
  ******************************************************************************/
 
-// UpdateSwitchSystemPasswordRequest updates the OS-level password for a user on a set of switch devices.
+// UpdateSwitchSystemPasswordRequest updates the OS-level password for a user on a set of switch nodes.
 message UpdateSwitchSystemPasswordRequest {
-  Metadata metadata = 1;
-  NodeSet nodes = 2;       // Switch devices to update
+  reserved 1;
+  reserved "metadata";
+  NodeSet nodes = 2;       // Switch nodes to update
   string username = 3;     // Target OS username whose password will be changed (mandatory)
   string password = 4;     // New password to set for the user (mandatory)
 }
@@ -1381,19 +1442,34 @@ message UpdateSwitchSystemPasswordResponse {
 }
 
 /*******************************************************************************
+ * UTILITY MESSAGES
+ ******************************************************************************/
+
+// VersionRequest retrieves server version information.
+message VersionRequest {
+}
+
+// VersionResponse reports server version information.
+message VersionResponse {
+  string version = 1;
+}
+
+/*******************************************************************************
  * FIRMWARE JOB STATUS MESSAGES
  ******************************************************************************/
 
 // GetFirmwareJobStatusRequest queries the status of an asynchronous firmware job.
 message GetFirmwareJobStatusRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string job_id = 2;       // Job ID returned from UpdateNodeFirmwareAsync or UpdateFirmwareByNodeTypeAsync
 }
 
 // GetFirmwareJobStatusResponse returns the current state of a firmware job.
 message GetFirmwareJobStatusResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;                 // SUCCESS if job found, FAILURE if job_id not found
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;                 // RETURN_CODE_SUCCESS if job found, RETURN_CODE_FAILURE if job_id not found
   string job_id = 3;                     // Echoed job ID
   FirmwareJobState job_state = 4;        // Current state of the firmware job
   string state_description = 5;          // Human-readable description of current state (e.g., "Installing firmware")
@@ -1402,20 +1478,22 @@ message GetFirmwareJobStatusResponse {
   FirmwareUpdateError error_code = 8;    // Error code if job failed
   string error_message = 9;             // Error details if job failed
   string result_json = 10;              // JSON with detailed result data (populated on completion)
-  int64 created_at = 11;                // Unix timestamp (ms) when job was created
-  int64 updated_at = 12;                // Unix timestamp (ms) when job was last updated
+  google.protobuf.Timestamp created_at = 11; // Time when job was created
+  google.protobuf.Timestamp updated_at = 12; // Time when job was last updated
 }
 
 // GetSwitchSystemImageJobStatusRequest queries the status of an asynchronous switch system image job.
 message GetSwitchSystemImageJobStatusRequest {
-  Metadata metadata = 1;
+  reserved 1;
+  reserved "metadata";
   string job_id = 2;       // Parent or child job ID returned from UpdateSwitchSystemImage
 }
 
 // GetSwitchSystemImageJobStatusResponse returns the current state of a switch system image job.
 message GetSwitchSystemImageJobStatusResponse {
-  Metadata metadata = 1;
-  ReturnCode status = 2;   // SUCCESS if job found, FAILURE if job_id not found
+  reserved 1;
+  reserved "metadata";
+  ReturnCode status = 2;   // RETURN_CODE_SUCCESS if job found, RETURN_CODE_FAILURE if job_id not found
   string job_id = 3;       // Echoed job ID
   string state = 4;        // queued, running, completed, or failed
   string message = 5;      // Human-readable progress description
@@ -1423,6 +1501,6 @@ message GetSwitchSystemImageJobStatusResponse {
   string node_id = 7;      // Node ID associated with this job; empty for parent jobs
   string error_message = 8; // Error details if job failed
   string result_json = 9;  // JSON with detailed result data (populated on completion)
-  int64 created_at = 10;   // Unix timestamp (ms) when job was created
-  int64 updated_at = 11;   // Unix timestamp (ms) when job was last updated
+  google.protobuf.Timestamp created_at = 10; // Time when job was created
+  google.protobuf.Timestamp updated_at = 11; // Time when job was last updated
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -354,7 +354,9 @@ impl<'a> RmsTlsClient<'a> {
 
                 // The thing we actually want to retry is a test connection
                 client
-                    .version(tonic::Request::new(()))
+                    .version(tonic::Request::new(
+                        crate::protos::rack_manager::VersionRequest {},
+                    ))
                     .await
                     .inspect_err(|err| {
                         tracing::error!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -354,8 +354,8 @@ impl<'a> RmsTlsClient<'a> {
 
                 // The thing we actually want to retry is a test connection
                 client
-                    .version(tonic::Request::new(
-                        crate::protos::rack_manager::VersionRequest {},
+                    .get_version(tonic::Request::new(
+                        crate::protos::rack_manager::GetVersionRequest {},
                     ))
                     .await
                     .inspect_err(|err| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,35 +178,36 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetPowerStateRequest,
     ) -> Result<rms::SetPowerStateResponse, RackManagerError>;
-    async fn set_power_state_by_node_list(
+    async fn batch_set_power_state(
         &self,
-        cmd: rms::SetPowerStateByNodeListRequest,
-    ) -> Result<rms::SetPowerStateByNodeListResponse, RackManagerError>;
+        cmd: rms::BatchSetPowerStateRequest,
+    ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError>;
     async fn get_power_state(
         &self,
         cmd: rms::GetPowerStateRequest,
     ) -> Result<rms::GetPowerStateResponse, RackManagerError>;
-    async fn get_power_state_by_node_list(
+    async fn batch_get_power_state(
         &self,
-        cmd: rms::GetPowerStateByNodeListRequest,
-    ) -> Result<rms::GetPowerStateByNodeListResponse, RackManagerError>;
+        cmd: rms::BatchGetPowerStateRequest,
+    ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError>;
     async fn sequence_rack_power(
         &self,
         cmd: rms::SequenceRackPowerRequest,
     ) -> Result<rms::SequenceRackPowerResponse, RackManagerError>;
-    async fn get_all_inventory(&self) -> Result<rms::GetAllInventoryResponse, RackManagerError>;
-    async fn add_node(
+    async fn list_node_inventory(&self)
+    -> Result<rms::ListNodeInventoryResponse, RackManagerError>;
+    async fn create_nodes(
         &self,
-        cmd: rms::AddNodeRequest,
-    ) -> Result<rms::AddNodeResponse, RackManagerError>;
+        cmd: rms::CreateNodesRequest,
+    ) -> Result<rms::CreateNodesResponse, RackManagerError>;
     async fn update_node(
         &self,
         cmd: rms::UpdateNodeRequest,
     ) -> Result<rms::UpdateNodeResponse, RackManagerError>;
-    async fn remove_node(
+    async fn delete_node(
         &self,
-        cmd: rms::RemoveNodeRequest,
-    ) -> Result<rms::RemoveNodeResponse, RackManagerError>;
+        cmd: rms::DeleteNodeRequest,
+    ) -> Result<rms::DeleteNodeResponse, RackManagerError>;
     async fn get_rack_power_on_sequence(
         &self,
         cmd: rms::GetRackPowerOnSequenceRequest,
@@ -220,14 +221,14 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetNodeDeviceInfoRequest,
     ) -> Result<rms::GetNodeDeviceInfoResponse, RackManagerError>;
-    async fn get_device_info_by_node_type(
+    async fn list_node_device_info_by_node_type(
         &self,
-        cmd: rms::GetDeviceInfoByNodeTypeRequest,
-    ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError>;
-    async fn get_device_info_by_node_list(
+        cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
+    ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError>;
+    async fn batch_get_node_device_info(
         &self,
-        cmd: rms::GetDeviceInfoByNodeListRequest,
-    ) -> Result<rms::GetDeviceInfoByNodeListResponse, RackManagerError>;
+        cmd: rms::BatchGetNodeDeviceInfoRequest,
+    ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>;
     async fn get_node_firmware_inventory(
         &self,
         cmd: rms::GetNodeFirmwareInventoryRequest,
@@ -236,14 +237,30 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetRackFirmwareInventoryRequest,
     ) -> Result<rms::GetRackFirmwareInventoryResponse, RackManagerError>;
+    async fn update_firmware(
+        &self,
+        cmd: rms::UpdateFirmwareRequest,
+    ) -> Result<rms::UpdateFirmwareResponse, RackManagerError>;
+    async fn batch_update_firmware_by_node_type(
+        &self,
+        cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
+    ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError>;
+    async fn batch_update_firmware(
+        &self,
+        cmd: rms::BatchUpdateFirmwareRequest,
+    ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError>;
+    async fn update_switch_system_image(
+        &self,
+        cmd: rms::UpdateSwitchSystemImageRequest,
+    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError>;
     async fn add_firmware_object(
         &self,
         cmd: rms::AddFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError>;
+    ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError>;
     async fn get_firmware_object(
         &self,
         cmd: rms::GetFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError>;
+    ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError>;
     async fn list_firmware_objects(
         &self,
         cmd: rms::ListFirmwareObjectsRequest,
@@ -251,59 +268,63 @@ pub trait RmsApi: Send + Sync + 'static {
     async fn delete_firmware_object(
         &self,
         cmd: rms::DeleteFirmwareObjectRequest,
-    ) -> Result<rms::OperationResponse, RackManagerError>;
+    ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError>;
     async fn set_default_firmware_object(
         &self,
         cmd: rms::SetDefaultFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError>;
+    ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError>;
+    async fn apply_stored_firmware_object(
+        &self,
+        cmd: rms::ApplyStoredFirmwareObjectRequest,
+    ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError>;
     async fn apply_firmware_object(
         &self,
         cmd: rms::ApplyFirmwareObjectRequest,
     ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError>;
-    async fn apply_firmware_object_from_json(
-        &self,
-        cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-    ) -> Result<rms::ApplyFirmwareObjectFromJsonResponse, RackManagerError>;
-    async fn apply_switch_system_image_from_json(
-        &self,
-        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-    ) -> Result<rms::ApplySwitchSystemImageFromJsonResponse, RackManagerError>;
     async fn apply_switch_system_image(
         &self,
         cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError>;
+    async fn apply_stored_switch_system_image(
+        &self,
+        cmd: rms::ApplyStoredSwitchSystemImageRequest,
+    ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError>;
     async fn get_firmware_object_history(
         &self,
         cmd: rms::GetFirmwareObjectHistoryRequest,
     ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError>;
-    async fn list_firmware_on_switch(
+    async fn list_switch_firmware(
         &self,
-        cmd: rms::ListFirmwareOnSwitchRequest,
-    ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError>;
-    async fn push_firmware_to_switch(
+        cmd: rms::ListSwitchFirmwareRequest,
+    ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError>;
+    async fn push_switch_firmware(
         &self,
-        cmd: rms::PushFirmwareToSwitchRequest,
-    ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError>;
-    async fn upgrade_firmware_on_switch(
+        cmd: rms::PushSwitchFirmwareRequest,
+    ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError>;
+    async fn upgrade_switch_firmware(
         &self,
-        cmd: rms::UpgradeFirmwareOnSwitchRequest,
-    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError>;
+        cmd: rms::UpgradeSwitchFirmwareRequest,
+    ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError>;
     async fn configure_scale_up_fabric_manager(
         &self,
         cmd: rms::ConfigureScaleUpFabricManagerRequest,
     ) -> Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>;
-    async fn set_scale_up_fabric_state(
+    async fn batch_set_scale_up_fabric_state(
         &self,
-        cmd: rms::SetScaleUpFabricStateRequest,
-    ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError>;
-    async fn get_scale_up_fabric_services_status(
+        cmd: rms::BatchSetScaleUpFabricStateRequest,
+    ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>;
+    async fn batch_get_scale_up_fabric_service_status(
         &self,
-        cmd: rms::GetScaleUpFabricServicesStatusRequest,
-    ) -> Result<rms::GetScaleUpFabricServicesStatusResponse, RackManagerError>;
+        cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
+    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>;
     async fn get_scale_up_fabric_state(
         &self,
         cmd: rms::GetScaleUpFabricStateRequest,
     ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError>;
+    async fn set_scale_up_fabric_telemetry_interface_state(
+        &self,
+        cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
+    ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>;
     async fn fetch_switch_system_image(
         &self,
         cmd: rms::FetchSwitchSystemImageRequest,
@@ -320,39 +341,19 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetSwitchSystemImageJobStatusRequest,
     ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>;
-    async fn enable_scale_up_fabric_telemetry_interface(
-        &self,
-        cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
-    ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError>;
-    async fn version(&self) -> Result<rms::VersionResponse, RackManagerError>;
-    async fn poll_job_status(
-        &self,
-        cmd: rms::PollJobStatusRequest,
-    ) -> Result<rms::PollJobStatusResponse, RackManagerError>;
-    async fn update_node_firmware_async(
-        &self,
-        cmd: rms::UpdateNodeFirmwareAsyncRequest,
-    ) -> Result<rms::UpdateNodeFirmwareAsyncResponse, RackManagerError>;
-    async fn update_firmware_by_node_type_async(
-        &self,
-        cmd: rms::UpdateFirmwareByNodeTypeAsyncRequest,
-    ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError>;
-    async fn update_firmware_by_node_list(
-        &self,
-        cmd: rms::UpdateFirmwareByNodeListRequest,
-    ) -> Result<rms::UpdateFirmwareByNodeListResponse, RackManagerError>;
-    async fn update_switch_system_image(
-        &self,
-        cmd: rms::UpdateSwitchSystemImageRequest,
-    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError>;
-    async fn get_firmware_job_status(
-        &self,
-        cmd: rms::GetFirmwareJobStatusRequest,
-    ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError>;
     async fn update_switch_system_password(
         &self,
         cmd: rms::UpdateSwitchSystemPasswordRequest,
     ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>;
+    async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError>;
+    async fn poll_switch_firmware_job_status(
+        &self,
+        cmd: rms::PollSwitchFirmwareJobStatusRequest,
+    ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError>;
+    async fn get_firmware_job_status(
+        &self,
+        cmd: rms::GetFirmwareJobStatusRequest,
+    ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError>;
 }
 
 #[async_trait::async_trait]
@@ -363,11 +364,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::SetPowerStateResponse, RackManagerError> {
         Ok(self.client.set_power_state(cmd).await?)
     }
-    async fn set_power_state_by_node_list(
+    async fn batch_set_power_state(
         &self,
-        cmd: rms::SetPowerStateByNodeListRequest,
-    ) -> Result<rms::SetPowerStateByNodeListResponse, RackManagerError> {
-        Ok(self.client.set_power_state_by_node_list(cmd).await?)
+        cmd: rms::BatchSetPowerStateRequest,
+    ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError> {
+        Ok(self.client.batch_set_power_state(cmd).await?)
     }
     async fn get_power_state(
         &self,
@@ -375,11 +376,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
         Ok(self.client.get_power_state(cmd).await?)
     }
-    async fn get_power_state_by_node_list(
+    async fn batch_get_power_state(
         &self,
-        cmd: rms::GetPowerStateByNodeListRequest,
-    ) -> Result<rms::GetPowerStateByNodeListResponse, RackManagerError> {
-        Ok(self.client.get_power_state_by_node_list(cmd).await?)
+        cmd: rms::BatchGetPowerStateRequest,
+    ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError> {
+        Ok(self.client.batch_get_power_state(cmd).await?)
     }
     async fn sequence_rack_power(
         &self,
@@ -387,14 +388,16 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::SequenceRackPowerResponse, RackManagerError> {
         Ok(self.client.sequence_rack_power(cmd).await?)
     }
-    async fn get_all_inventory(&self) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
-        Ok(self.client.get_all_inventory().await?)
-    }
-    async fn add_node(
+    async fn list_node_inventory(
         &self,
-        cmd: rms::AddNodeRequest,
-    ) -> Result<rms::AddNodeResponse, RackManagerError> {
-        Ok(self.client.add_node(cmd).await?)
+    ) -> Result<rms::ListNodeInventoryResponse, RackManagerError> {
+        Ok(self.client.list_node_inventory().await?)
+    }
+    async fn create_nodes(
+        &self,
+        cmd: rms::CreateNodesRequest,
+    ) -> Result<rms::CreateNodesResponse, RackManagerError> {
+        Ok(self.client.create_nodes(cmd).await?)
     }
     async fn update_node(
         &self,
@@ -402,11 +405,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::UpdateNodeResponse, RackManagerError> {
         Ok(self.client.update_node(cmd).await?)
     }
-    async fn remove_node(
+    async fn delete_node(
         &self,
-        cmd: rms::RemoveNodeRequest,
-    ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
-        Ok(self.client.remove_node(cmd).await?)
+        cmd: rms::DeleteNodeRequest,
+    ) -> Result<rms::DeleteNodeResponse, RackManagerError> {
+        Ok(self.client.delete_node(cmd).await?)
     }
     async fn get_rack_power_on_sequence(
         &self,
@@ -429,17 +432,17 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetNodeDeviceInfoResponse, RackManagerError> {
         Ok(self.client.get_node_device_info(cmd).await?)
     }
-    async fn get_device_info_by_node_type(
+    async fn list_node_device_info_by_node_type(
         &self,
-        cmd: rms::GetDeviceInfoByNodeTypeRequest,
-    ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
-        Ok(self.client.get_device_info_by_node_type(cmd).await?)
+        cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
+    ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError> {
+        Ok(self.client.list_node_device_info_by_node_type(cmd).await?)
     }
-    async fn get_device_info_by_node_list(
+    async fn batch_get_node_device_info(
         &self,
-        cmd: rms::GetDeviceInfoByNodeListRequest,
-    ) -> Result<rms::GetDeviceInfoByNodeListResponse, RackManagerError> {
-        Ok(self.client.get_device_info_by_node_list(cmd).await?)
+        cmd: rms::BatchGetNodeDeviceInfoRequest,
+    ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError> {
+        Ok(self.client.batch_get_node_device_info(cmd).await?)
     }
     async fn get_node_firmware_inventory(
         &self,
@@ -453,16 +456,40 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetRackFirmwareInventoryResponse, RackManagerError> {
         Ok(self.client.get_rack_firmware_inventory(cmd).await?)
     }
+    async fn update_firmware(
+        &self,
+        cmd: rms::UpdateFirmwareRequest,
+    ) -> Result<rms::UpdateFirmwareResponse, RackManagerError> {
+        Ok(self.client.update_firmware(cmd).await?)
+    }
+    async fn batch_update_firmware_by_node_type(
+        &self,
+        cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
+    ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError> {
+        Ok(self.client.batch_update_firmware_by_node_type(cmd).await?)
+    }
+    async fn batch_update_firmware(
+        &self,
+        cmd: rms::BatchUpdateFirmwareRequest,
+    ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError> {
+        Ok(self.client.batch_update_firmware(cmd).await?)
+    }
+    async fn update_switch_system_image(
+        &self,
+        cmd: rms::UpdateSwitchSystemImageRequest,
+    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
+        Ok(self.client.update_switch_system_image(cmd).await?)
+    }
     async fn add_firmware_object(
         &self,
         cmd: rms::AddFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError> {
         Ok(self.client.add_firmware_object(cmd).await?)
     }
     async fn get_firmware_object(
         &self,
         cmd: rms::GetFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError> {
         Ok(self.client.get_firmware_object(cmd).await?)
     }
     async fn list_firmware_objects(
@@ -474,14 +501,20 @@ impl RmsApi for RackManagerApi {
     async fn delete_firmware_object(
         &self,
         cmd: rms::DeleteFirmwareObjectRequest,
-    ) -> Result<rms::OperationResponse, RackManagerError> {
+    ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError> {
         Ok(self.client.delete_firmware_object(cmd).await?)
     }
     async fn set_default_firmware_object(
         &self,
         cmd: rms::SetDefaultFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError> {
         Ok(self.client.set_default_firmware_object(cmd).await?)
+    }
+    async fn apply_stored_firmware_object(
+        &self,
+        cmd: rms::ApplyStoredFirmwareObjectRequest,
+    ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError> {
+        Ok(self.client.apply_stored_firmware_object(cmd).await?)
     }
     async fn apply_firmware_object(
         &self,
@@ -489,23 +522,17 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
         Ok(self.client.apply_firmware_object(cmd).await?)
     }
-    async fn apply_firmware_object_from_json(
-        &self,
-        cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-    ) -> Result<rms::ApplyFirmwareObjectFromJsonResponse, RackManagerError> {
-        Ok(self.client.apply_firmware_object_from_json(cmd).await?)
-    }
-    async fn apply_switch_system_image_from_json(
-        &self,
-        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-    ) -> Result<rms::ApplySwitchSystemImageFromJsonResponse, RackManagerError> {
-        Ok(self.client.apply_switch_system_image_from_json(cmd).await?)
-    }
     async fn apply_switch_system_image(
         &self,
         cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
         Ok(self.client.apply_switch_system_image(cmd).await?)
+    }
+    async fn apply_stored_switch_system_image(
+        &self,
+        cmd: rms::ApplyStoredSwitchSystemImageRequest,
+    ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError> {
+        Ok(self.client.apply_stored_switch_system_image(cmd).await?)
     }
     async fn get_firmware_object_history(
         &self,
@@ -513,23 +540,23 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError> {
         Ok(self.client.get_firmware_object_history(cmd).await?)
     }
-    async fn list_firmware_on_switch(
+    async fn list_switch_firmware(
         &self,
-        cmd: rms::ListFirmwareOnSwitchRequest,
-    ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
-        Ok(self.client.list_firmware_on_switch(cmd).await?)
+        cmd: rms::ListSwitchFirmwareRequest,
+    ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError> {
+        Ok(self.client.list_switch_firmware(cmd).await?)
     }
-    async fn push_firmware_to_switch(
+    async fn push_switch_firmware(
         &self,
-        cmd: rms::PushFirmwareToSwitchRequest,
-    ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
-        Ok(self.client.push_firmware_to_switch(cmd).await?)
+        cmd: rms::PushSwitchFirmwareRequest,
+    ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
+        Ok(self.client.push_switch_firmware(cmd).await?)
     }
-    async fn upgrade_firmware_on_switch(
+    async fn upgrade_switch_firmware(
         &self,
-        cmd: rms::UpgradeFirmwareOnSwitchRequest,
-    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
-        Ok(self.client.upgrade_firmware_on_switch(cmd).await?)
+        cmd: rms::UpgradeSwitchFirmwareRequest,
+    ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
+        Ok(self.client.upgrade_switch_firmware(cmd).await?)
     }
     async fn configure_scale_up_fabric_manager(
         &self,
@@ -537,23 +564,35 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError> {
         Ok(self.client.configure_scale_up_fabric_manager(cmd).await?)
     }
-    async fn set_scale_up_fabric_state(
+    async fn batch_set_scale_up_fabric_state(
         &self,
-        cmd: rms::SetScaleUpFabricStateRequest,
-    ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
-        Ok(self.client.set_scale_up_fabric_state(cmd).await?)
+        cmd: rms::BatchSetScaleUpFabricStateRequest,
+    ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError> {
+        Ok(self.client.batch_set_scale_up_fabric_state(cmd).await?)
     }
-    async fn get_scale_up_fabric_services_status(
+    async fn batch_get_scale_up_fabric_service_status(
         &self,
-        cmd: rms::GetScaleUpFabricServicesStatusRequest,
-    ) -> Result<rms::GetScaleUpFabricServicesStatusResponse, RackManagerError> {
-        Ok(self.client.get_scale_up_fabric_services_status(cmd).await?)
+        cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
+    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError> {
+        Ok(self
+            .client
+            .batch_get_scale_up_fabric_service_status(cmd)
+            .await?)
     }
     async fn get_scale_up_fabric_state(
         &self,
         cmd: rms::GetScaleUpFabricStateRequest,
     ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
         Ok(self.client.get_scale_up_fabric_state(cmd).await?)
+    }
+    async fn set_scale_up_fabric_telemetry_interface_state(
+        &self,
+        cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
+    ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError> {
+        Ok(self
+            .client
+            .set_scale_up_fabric_telemetry_interface_state(cmd)
+            .await?)
     }
     async fn fetch_switch_system_image(
         &self,
@@ -579,59 +618,26 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
         Ok(self.client.get_switch_system_image_job_status(cmd).await?)
     }
-    async fn enable_scale_up_fabric_telemetry_interface(
+    async fn update_switch_system_password(
         &self,
-        cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
-    ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
-        Ok(self
-            .client
-            .enable_scale_up_fabric_telemetry_interface(cmd)
-            .await?)
+        cmd: rms::UpdateSwitchSystemPasswordRequest,
+    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
+        Ok(self.client.update_switch_system_password(cmd).await?)
     }
-    async fn version(&self) -> Result<rms::VersionResponse, RackManagerError> {
-        Ok(self.client.version().await?)
+    async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError> {
+        Ok(self.client.get_version().await?)
     }
-    async fn poll_job_status(
+    async fn poll_switch_firmware_job_status(
         &self,
-        cmd: rms::PollJobStatusRequest,
-    ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
-        Ok(self.client.poll_job_status(cmd).await?)
-    }
-    async fn update_node_firmware_async(
-        &self,
-        cmd: rms::UpdateNodeFirmwareAsyncRequest,
-    ) -> Result<rms::UpdateNodeFirmwareAsyncResponse, RackManagerError> {
-        Ok(self.client.update_node_firmware_async(cmd).await?)
-    }
-    async fn update_firmware_by_node_type_async(
-        &self,
-        cmd: rms::UpdateFirmwareByNodeTypeAsyncRequest,
-    ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
-        Ok(self.client.update_firmware_by_node_type_async(cmd).await?)
-    }
-    async fn update_firmware_by_node_list(
-        &self,
-        cmd: rms::UpdateFirmwareByNodeListRequest,
-    ) -> Result<rms::UpdateFirmwareByNodeListResponse, RackManagerError> {
-        Ok(self.client.update_firmware_by_node_list(cmd).await?)
-    }
-    async fn update_switch_system_image(
-        &self,
-        cmd: rms::UpdateSwitchSystemImageRequest,
-    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
-        Ok(self.client.update_switch_system_image(cmd).await?)
+        cmd: rms::PollSwitchFirmwareJobStatusRequest,
+    ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError> {
+        Ok(self.client.poll_switch_firmware_job_status(cmd).await?)
     }
     async fn get_firmware_job_status(
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
     ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError> {
         Ok(self.client.get_firmware_job_status(cmd).await?)
-    }
-    async fn update_switch_system_password(
-        &self,
-        cmd: rms::UpdateSwitchSystemPasswordRequest,
-    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
-        Ok(self.client.update_switch_system_password(cmd).await?)
     }
 }
 
@@ -732,6 +738,7 @@ mod tests {
     fn proto_types_implement_serde() {
         // Plain message
         assert_serde::<rms::Credentials>();
+        assert_serde::<rms::ComponentInventoryInfo>();
 
         // Oneof enum - the case that previously required special handling in build.rs
         assert_serde::<rms::credentials::Auth>();
@@ -743,8 +750,8 @@ mod tests {
         // Representative request/response pair
         assert_serde::<rms::SetPowerStateRequest>();
         assert_serde::<rms::SetPowerStateResponse>();
-        assert_serde::<rms::SetScaleUpFabricStateRequest>();
-        assert_serde::<rms::SetScaleUpFabricStateResponse>();
+        assert_serde::<rms::BatchSetScaleUpFabricStateRequest>();
+        assert_serde::<rms::BatchSetScaleUpFabricStateResponse>();
 
         // Timestamp-backed responses
         assert_serde::<rms::GetFirmwareJobStatusResponse>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,6 @@ use tonic::Status;
 use crate::client::{RackManagerClientT, RetryConfig, RmsApiConfig, RmsTlsClient};
 use crate::client_config::RmsClientConfig;
 use crate::protos::rack_manager as rms;
-use crate::protos::rack_manager::{
-    UpgradeFirmwareOnSwitchCommand, UpgradeFirmwareOnSwitchResponse,
-};
 use crate::protos::rack_manager_client::RackManagerApiClient;
 pub mod client;
 pub mod client_config;
@@ -181,26 +178,23 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetPowerStateRequest,
     ) -> Result<rms::SetPowerStateResponse, RackManagerError>;
-    async fn set_power_state_by_device_list(
+    async fn set_power_state_by_node_list(
         &self,
-        cmd: rms::SetPowerStateByDeviceListRequest,
-    ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>;
+        cmd: rms::SetPowerStateByNodeListRequest,
+    ) -> Result<rms::SetPowerStateByNodeListResponse, RackManagerError>;
     async fn get_power_state(
         &self,
         cmd: rms::GetPowerStateRequest,
     ) -> Result<rms::GetPowerStateResponse, RackManagerError>;
-    async fn get_power_state_by_device_list(
+    async fn get_power_state_by_node_list(
         &self,
-        cmd: rms::GetPowerStateByDeviceListRequest,
-    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>;
+        cmd: rms::GetPowerStateByNodeListRequest,
+    ) -> Result<rms::GetPowerStateByNodeListResponse, RackManagerError>;
     async fn sequence_rack_power(
         &self,
         cmd: rms::SequenceRackPowerRequest,
     ) -> Result<rms::SequenceRackPowerResponse, RackManagerError>;
-    async fn get_all_inventory(
-        &self,
-        cmd: rms::GetAllInventoryRequest,
-    ) -> Result<rms::GetAllInventoryResponse, RackManagerError>;
+    async fn get_all_inventory(&self) -> Result<rms::GetAllInventoryResponse, RackManagerError>;
     async fn add_node(
         &self,
         cmd: rms::AddNodeRequest,
@@ -221,10 +215,7 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetRackPowerOnSequenceRequest,
     ) -> Result<rms::SetRackPowerOnSequenceResponse, RackManagerError>;
-    async fn list_racks(
-        &self,
-        cmd: rms::ListRacksRequest,
-    ) -> Result<rms::ListRacksResponse, RackManagerError>;
+    async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError>;
     async fn get_node_device_info(
         &self,
         cmd: rms::GetNodeDeviceInfoRequest,
@@ -233,10 +224,10 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetDeviceInfoByNodeTypeRequest,
     ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError>;
-    async fn get_device_info_by_device_list(
+    async fn get_device_info_by_node_list(
         &self,
-        cmd: rms::GetDeviceInfoByDeviceListRequest,
-    ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>;
+        cmd: rms::GetDeviceInfoByNodeListRequest,
+    ) -> Result<rms::GetDeviceInfoByNodeListResponse, RackManagerError>;
     async fn get_node_firmware_inventory(
         &self,
         cmd: rms::GetNodeFirmwareInventoryRequest,
@@ -272,11 +263,11 @@ pub trait RmsApi: Send + Sync + 'static {
     async fn apply_firmware_object_from_json(
         &self,
         cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError>;
+    ) -> Result<rms::ApplyFirmwareObjectFromJsonResponse, RackManagerError>;
     async fn apply_switch_system_image_from_json(
         &self,
         cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError>;
+    ) -> Result<rms::ApplySwitchSystemImageFromJsonResponse, RackManagerError>;
     async fn apply_switch_system_image(
         &self,
         cmd: rms::ApplySwitchSystemImageRequest,
@@ -287,15 +278,15 @@ pub trait RmsApi: Send + Sync + 'static {
     ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError>;
     async fn list_firmware_on_switch(
         &self,
-        cmd: rms::ListFirmwareOnSwitchCommand,
+        cmd: rms::ListFirmwareOnSwitchRequest,
     ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError>;
     async fn push_firmware_to_switch(
         &self,
-        cmd: rms::PushFirmwareToSwitchCommand,
+        cmd: rms::PushFirmwareToSwitchRequest,
     ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError>;
     async fn upgrade_firmware_on_switch(
         &self,
-        cmd: rms::UpgradeFirmwareOnSwitchCommand,
+        cmd: rms::UpgradeFirmwareOnSwitchRequest,
     ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError>;
     async fn configure_scale_up_fabric_manager(
         &self,
@@ -305,6 +296,14 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetScaleUpFabricStateRequest,
     ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError>;
+    async fn get_scale_up_fabric_services_status(
+        &self,
+        cmd: rms::GetScaleUpFabricServicesStatusRequest,
+    ) -> Result<rms::GetScaleUpFabricServicesStatusResponse, RackManagerError>;
+    async fn get_scale_up_fabric_state(
+        &self,
+        cmd: rms::GetScaleUpFabricStateRequest,
+    ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError>;
     async fn fetch_switch_system_image(
         &self,
         cmd: rms::FetchSwitchSystemImageRequest,
@@ -317,27 +316,35 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::ListSwitchSystemImagesRequest,
     ) -> Result<rms::ListSwitchSystemImagesResponse, RackManagerError>;
+    async fn get_switch_system_image_job_status(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>;
     async fn enable_scale_up_fabric_telemetry_interface(
         &self,
         cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
     ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError>;
-    async fn version(&self) -> Result<(), RackManagerError>;
+    async fn version(&self) -> Result<rms::VersionResponse, RackManagerError>;
     async fn poll_job_status(
         &self,
-        cmd: rms::PollJobStatusCommand,
+        cmd: rms::PollJobStatusRequest,
     ) -> Result<rms::PollJobStatusResponse, RackManagerError>;
     async fn update_node_firmware_async(
         &self,
-        cmd: rms::UpdateNodeFirmwareRequest,
-    ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError>;
+        cmd: rms::UpdateNodeFirmwareAsyncRequest,
+    ) -> Result<rms::UpdateNodeFirmwareAsyncResponse, RackManagerError>;
     async fn update_firmware_by_node_type_async(
         &self,
-        cmd: rms::UpdateFirmwareByNodeTypeRequest,
+        cmd: rms::UpdateFirmwareByNodeTypeAsyncRequest,
     ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError>;
-    async fn update_firmware_by_device_list(
+    async fn update_firmware_by_node_list(
         &self,
-        cmd: rms::UpdateFirmwareByDeviceListRequest,
-    ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError>;
+        cmd: rms::UpdateFirmwareByNodeListRequest,
+    ) -> Result<rms::UpdateFirmwareByNodeListResponse, RackManagerError>;
+    async fn update_switch_system_image(
+        &self,
+        cmd: rms::UpdateSwitchSystemImageRequest,
+    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError>;
     async fn get_firmware_job_status(
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
@@ -356,11 +363,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::SetPowerStateResponse, RackManagerError> {
         Ok(self.client.set_power_state(cmd).await?)
     }
-    async fn set_power_state_by_device_list(
+    async fn set_power_state_by_node_list(
         &self,
-        cmd: rms::SetPowerStateByDeviceListRequest,
-    ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
-        Ok(self.client.set_power_state_by_device_list(cmd).await?)
+        cmd: rms::SetPowerStateByNodeListRequest,
+    ) -> Result<rms::SetPowerStateByNodeListResponse, RackManagerError> {
+        Ok(self.client.set_power_state_by_node_list(cmd).await?)
     }
     async fn get_power_state(
         &self,
@@ -368,11 +375,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
         Ok(self.client.get_power_state(cmd).await?)
     }
-    async fn get_power_state_by_device_list(
+    async fn get_power_state_by_node_list(
         &self,
-        cmd: rms::GetPowerStateByDeviceListRequest,
-    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
-        Ok(self.client.get_power_state_by_device_list(cmd).await?)
+        cmd: rms::GetPowerStateByNodeListRequest,
+    ) -> Result<rms::GetPowerStateByNodeListResponse, RackManagerError> {
+        Ok(self.client.get_power_state_by_node_list(cmd).await?)
     }
     async fn sequence_rack_power(
         &self,
@@ -380,11 +387,8 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::SequenceRackPowerResponse, RackManagerError> {
         Ok(self.client.sequence_rack_power(cmd).await?)
     }
-    async fn get_all_inventory(
-        &self,
-        cmd: rms::GetAllInventoryRequest,
-    ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
-        Ok(self.client.get_all_inventory(cmd).await?)
+    async fn get_all_inventory(&self) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
+        Ok(self.client.get_all_inventory().await?)
     }
     async fn add_node(
         &self,
@@ -416,11 +420,8 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::SetRackPowerOnSequenceResponse, RackManagerError> {
         Ok(self.client.set_rack_power_on_sequence(cmd).await?)
     }
-    async fn list_racks(
-        &self,
-        cmd: rms::ListRacksRequest,
-    ) -> Result<rms::ListRacksResponse, RackManagerError> {
-        Ok(self.client.list_racks(cmd).await?)
+    async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError> {
+        Ok(self.client.list_racks().await?)
     }
     async fn get_node_device_info(
         &self,
@@ -434,11 +435,11 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
         Ok(self.client.get_device_info_by_node_type(cmd).await?)
     }
-    async fn get_device_info_by_device_list(
+    async fn get_device_info_by_node_list(
         &self,
-        cmd: rms::GetDeviceInfoByDeviceListRequest,
-    ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
-        Ok(self.client.get_device_info_by_device_list(cmd).await?)
+        cmd: rms::GetDeviceInfoByNodeListRequest,
+    ) -> Result<rms::GetDeviceInfoByNodeListResponse, RackManagerError> {
+        Ok(self.client.get_device_info_by_node_list(cmd).await?)
     }
     async fn get_node_firmware_inventory(
         &self,
@@ -491,13 +492,13 @@ impl RmsApi for RackManagerApi {
     async fn apply_firmware_object_from_json(
         &self,
         cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
+    ) -> Result<rms::ApplyFirmwareObjectFromJsonResponse, RackManagerError> {
         Ok(self.client.apply_firmware_object_from_json(cmd).await?)
     }
     async fn apply_switch_system_image_from_json(
         &self,
         cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
+    ) -> Result<rms::ApplySwitchSystemImageFromJsonResponse, RackManagerError> {
         Ok(self.client.apply_switch_system_image_from_json(cmd).await?)
     }
     async fn apply_switch_system_image(
@@ -514,20 +515,20 @@ impl RmsApi for RackManagerApi {
     }
     async fn list_firmware_on_switch(
         &self,
-        cmd: rms::ListFirmwareOnSwitchCommand,
+        cmd: rms::ListFirmwareOnSwitchRequest,
     ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
         Ok(self.client.list_firmware_on_switch(cmd).await?)
     }
     async fn push_firmware_to_switch(
         &self,
-        cmd: rms::PushFirmwareToSwitchCommand,
+        cmd: rms::PushFirmwareToSwitchRequest,
     ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
         Ok(self.client.push_firmware_to_switch(cmd).await?)
     }
     async fn upgrade_firmware_on_switch(
         &self,
-        cmd: UpgradeFirmwareOnSwitchCommand,
-    ) -> Result<UpgradeFirmwareOnSwitchResponse, RackManagerError> {
+        cmd: rms::UpgradeFirmwareOnSwitchRequest,
+    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
         Ok(self.client.upgrade_firmware_on_switch(cmd).await?)
     }
     async fn configure_scale_up_fabric_manager(
@@ -541,6 +542,18 @@ impl RmsApi for RackManagerApi {
         cmd: rms::SetScaleUpFabricStateRequest,
     ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
         Ok(self.client.set_scale_up_fabric_state(cmd).await?)
+    }
+    async fn get_scale_up_fabric_services_status(
+        &self,
+        cmd: rms::GetScaleUpFabricServicesStatusRequest,
+    ) -> Result<rms::GetScaleUpFabricServicesStatusResponse, RackManagerError> {
+        Ok(self.client.get_scale_up_fabric_services_status(cmd).await?)
+    }
+    async fn get_scale_up_fabric_state(
+        &self,
+        cmd: rms::GetScaleUpFabricStateRequest,
+    ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
+        Ok(self.client.get_scale_up_fabric_state(cmd).await?)
     }
     async fn fetch_switch_system_image(
         &self,
@@ -560,6 +573,12 @@ impl RmsApi for RackManagerApi {
     ) -> Result<rms::ListSwitchSystemImagesResponse, RackManagerError> {
         Ok(self.client.list_switch_system_images(cmd).await?)
     }
+    async fn get_switch_system_image_job_status(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+        Ok(self.client.get_switch_system_image_job_status(cmd).await?)
+    }
     async fn enable_scale_up_fabric_telemetry_interface(
         &self,
         cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
@@ -569,32 +588,38 @@ impl RmsApi for RackManagerApi {
             .enable_scale_up_fabric_telemetry_interface(cmd)
             .await?)
     }
-    async fn version(&self) -> Result<(), RackManagerError> {
+    async fn version(&self) -> Result<rms::VersionResponse, RackManagerError> {
         Ok(self.client.version().await?)
     }
     async fn poll_job_status(
         &self,
-        cmd: rms::PollJobStatusCommand,
+        cmd: rms::PollJobStatusRequest,
     ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
         Ok(self.client.poll_job_status(cmd).await?)
     }
     async fn update_node_firmware_async(
         &self,
-        cmd: rms::UpdateNodeFirmwareRequest,
-    ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
+        cmd: rms::UpdateNodeFirmwareAsyncRequest,
+    ) -> Result<rms::UpdateNodeFirmwareAsyncResponse, RackManagerError> {
         Ok(self.client.update_node_firmware_async(cmd).await?)
     }
     async fn update_firmware_by_node_type_async(
         &self,
-        cmd: rms::UpdateFirmwareByNodeTypeRequest,
+        cmd: rms::UpdateFirmwareByNodeTypeAsyncRequest,
     ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
         Ok(self.client.update_firmware_by_node_type_async(cmd).await?)
     }
-    async fn update_firmware_by_device_list(
+    async fn update_firmware_by_node_list(
         &self,
-        cmd: rms::UpdateFirmwareByDeviceListRequest,
-    ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
-        Ok(self.client.update_firmware_by_device_list(cmd).await?)
+        cmd: rms::UpdateFirmwareByNodeListRequest,
+    ) -> Result<rms::UpdateFirmwareByNodeListResponse, RackManagerError> {
+        Ok(self.client.update_firmware_by_node_list(cmd).await?)
+    }
+    async fn update_switch_system_image(
+        &self,
+        cmd: rms::UpdateSwitchSystemImageRequest,
+    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
+        Ok(self.client.update_switch_system_image(cmd).await?)
     }
     async fn get_firmware_job_status(
         &self,
@@ -701,14 +726,14 @@ mod tests {
     /// Verifies that the single package-level type_attribute(".rack_manager", ...) in
     /// build.rs correctly applies serde derives to all proto-generated types. Covers
     /// the structurally distinct categories: plain messages, the oneof enum nested inside
-    /// Credentials (which previously needed separate handling), top-level enums, and a
-    /// request/response pair.
+    /// Credentials (which previously needed separate handling), top-level enums,
+    /// request/response pairs, and timestamp-backed responses.
     #[test]
     fn proto_types_implement_serde() {
         // Plain message
         assert_serde::<rms::Credentials>();
 
-        // Oneof enum — the case that previously required special handling in build.rs
+        // Oneof enum - the case that previously required special handling in build.rs
         assert_serde::<rms::credentials::Auth>();
 
         // Top-level enums
@@ -720,5 +745,9 @@ mod tests {
         assert_serde::<rms::SetPowerStateResponse>();
         assert_serde::<rms::SetScaleUpFabricStateRequest>();
         assert_serde::<rms::SetScaleUpFabricStateResponse>();
+
+        // Timestamp-backed responses
+        assert_serde::<rms::GetFirmwareJobStatusResponse>();
+        assert_serde::<rms::GetSwitchSystemImageJobStatusResponse>();
     }
 }


### PR DESCRIPTION
## Description
This PR cleans up `rack_manager.proto` and updates the RMS code to match the new API.

The main goal is to make the proto easier for clients to use and harder to misuse. The changes remove fields RMS was not actually using, make naming more consistent, and use protobuf-native types where they fit better.

Key updates:
- Removed request/response `Metadata` fields. Correlation and identity should come from gRPC metadata, headers, TLS, or interceptors.
- Added explicit `UNSPECIFIED = 0` enum values so proto3 defaults do not mean a real operation or success.
- Standardized node naming: `NewNodeInfo` is now `NodeInfo`, `devices` is now `nodes`, and `DeviceList` RPCs are now `NodeList`.
- Changed numeric fields that cannot be negative to unsigned types.
- Changed firmware `updateable` from `string` to `bool`.
- Replaced raw millisecond timestamps with `google.protobuf.Timestamp`.
- Removed switch request fields such as `port` and `verify_ssl` where the handler ignored them and used inventory data instead.
- Removed redundant response status fields from simple inventory list RPCs.
- Aligned `FromJson` RPC/message naming.
- Marked the deprecated component filter field with `[deprecated = true]`.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [x] This PR contains breaking changes

This is a breaking proto/API cleanup. Clients will need to update renamed messages, fields, RPCs, and enum values. They will also need to stop sending removed metadata fields and ignored switch fields.

Migration notes:
- Use gRPC metadata, headers, TLS identity, or interceptors instead of request/response `Metadata`.
- Use `NodeInfo` and `NodeSet.nodes`.
- Use `*NodeList` RPC/request/response names instead of `*DeviceList`.
- Update enum references to the new normalized names.
- Use protobuf `Timestamp` helpers for job time fields.
- Stop sending `port` and `verify_ssl` on inventory-backed switch RPCs.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This PR does not try to normalize every result/status response shape. That would require broader behavior changes in RMS, especially for batch and partial-failure flows. This PR keeps that behavior stable and focuses on the proto cleanup that can be done safely now.