### PR TITLE
proto(error): add a firmware update error code for in-flight update conflict

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -71,6 +71,7 @@ enum FirmwareUpdateError {
   FIRMWARE_UPDATE_ERROR_MONITORING_TIMEOUT = 10;  // Timed out waiting for update to complete
   FIRMWARE_UPDATE_ERROR_TASK_EXCEPTION     = 11;  // Exception in task monitoring
   FIRMWARE_UPDATE_ERROR_UNKNOWN            = 12;  // Unknown or unclassified error
+  FIRMWARE_UPDATE_ERROR_UPDATE_IN_PROGRESS = 13;  // The node already has an active firmware update.
 }
 
 // NodeType identifies the hardware-specific node implementation in the rack.


### PR DESCRIPTION
RMS should reject any firmware update request on the same node when there is already an in-flight update. This new code helps signal to the caller regarding the exact cause of error.