### PR TITLE
cleanup fetch and install RPCs (handled by update)

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -552,18 +552,6 @@ service RackManager {
    *-------------------------------------------------------------------------*/
 
   /*
-   * FetchSwitchSystemImage downloads a switch OS image from a remote URL to the switch.
-   * Returns a job ID for tracking the download progress.
-   */
-  rpc FetchSwitchSystemImage(FetchSwitchSystemImageRequest) returns (FetchSwitchSystemImageResponse) {}
-
-  /*
-   * InstallSwitchSystemImage installs a previously fetched OS image on the switch.
-   * Returns a job ID for tracking the installation progress.
-   */
-  rpc InstallSwitchSystemImage(InstallSwitchSystemImageRequest) returns (InstallSwitchSystemImageResponse) {}
-
-  /*
    * ListSwitchSystemImages retrieves the list of OS images available on the switch.
    * Returns information about installed and staged images.
    */
@@ -1187,34 +1175,6 @@ message GetScaleUpFabricStateResponse {
  * Connection settings, credentials, port, and TLS validation behavior are
  * resolved from the node's stored inventory data.
  ******************************************************************************/
-
-// FetchSwitchSystemImageRequest downloads an OS image to a switch.
-message FetchSwitchSystemImageRequest {
-  string rack_id = 2; // Rack containing the target switch
-  string node_id = 3; // Target switch node identifier
-  string remote_url = 6; // URL to download the system image from
-}
-
-// FetchSwitchSystemImageResponse reports the download initiation result.
-message FetchSwitchSystemImageResponse {
-  ReturnCode status = 2; // RETURN_CODE_SUCCESS if download started, RETURN_CODE_FAILURE otherwise
-  string job_id = 3; // Job identifier for tracking download progress
-  string error_message = 4; // Error details if download failed to start
-}
-
-// InstallSwitchSystemImageRequest installs an OS image on a switch.
-message InstallSwitchSystemImageRequest {
-  string rack_id = 2; // Rack containing the target switch
-  string node_id = 3; // Target switch node identifier
-  string image_filename = 6; // Filename of the image to install (must be fetched first)
-}
-
-// InstallSwitchSystemImageResponse reports the installation initiation result.
-message InstallSwitchSystemImageResponse {
-  ReturnCode status = 2; // RETURN_CODE_SUCCESS if installation started, RETURN_CODE_FAILURE otherwise
-  string job_id = 3; // Job identifier for tracking installation progress
-  string error_message = 4; // Error details if installation failed to start
-}
 
 // ListSwitchSystemImagesRequest retrieves available OS images on a switch.
 message ListSwitchSystemImagesRequest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,14 +325,6 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
     ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>;
-    async fn fetch_switch_system_image(
-        &self,
-        cmd: rms::FetchSwitchSystemImageRequest,
-    ) -> Result<rms::FetchSwitchSystemImageResponse, RackManagerError>;
-    async fn install_switch_system_image(
-        &self,
-        cmd: rms::InstallSwitchSystemImageRequest,
-    ) -> Result<rms::InstallSwitchSystemImageResponse, RackManagerError>;
     async fn list_switch_system_images(
         &self,
         cmd: rms::ListSwitchSystemImagesRequest,
@@ -593,18 +585,6 @@ impl RmsApi for RackManagerApi {
             .client
             .set_scale_up_fabric_telemetry_interface_state(cmd)
             .await?)
-    }
-    async fn fetch_switch_system_image(
-        &self,
-        cmd: rms::FetchSwitchSystemImageRequest,
-    ) -> Result<rms::FetchSwitchSystemImageResponse, RackManagerError> {
-        Ok(self.client.fetch_switch_system_image(cmd).await?)
-    }
-    async fn install_switch_system_image(
-        &self,
-        cmd: rms::InstallSwitchSystemImageRequest,
-    ) -> Result<rms::InstallSwitchSystemImageResponse, RackManagerError> {
-        Ok(self.client.install_switch_system_image(cmd).await?)
     }
     async fn list_switch_system_images(
         &self,


### PR DESCRIPTION
We are no longer using fetch+install switch image installation method