### PR TITLE
feat(proto): add optional domain selector to switch TLS RPCs

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1137,7 +1137,7 @@ message FirmwareObjectHistoryRecord {
 message ConfigureScaleUpFabricManagerRequest {
   NodeInfo node = 2; // Target switch identity and direct connection information
   string topology_type = 3; // Topology to be set for ScaleUpFabric
-  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.
+  optional string domain = 4; // Optional site selector; defaults to --default-switch-domain when unset.
 }
 
 // ConfigureScaleUpFabricManagerResponse reports the ScaleUpFabricManager  configuration result.
@@ -1205,7 +1205,7 @@ message ConfigureSwitchCertificateRequest {
   NodeSet nodes = 1; // Switch nodes to update
   repeated SwitchService services = 2; // Switch services to protect with the installed mTLS certificates
   bool test_hello = 3; // Test Hello Connection over mTLS
-  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.  
+  optional string domain = 4; // Optional site selector; defaults to --default-switch-domain when unset.  
 }
 
 // ConfigureSwitchCertificateResponse reports switch certificate configuration job creation results.

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1146,6 +1146,7 @@ message ConfigureScaleUpFabricManagerResponse {
   string topology_used = 4; // multi-node scaleup topology that was applied
   bool scale_up_fabric_state_enabled = 5; // Whether the ScaleUpFabricState State is now enabled
   bool grpc_enabled = 6; // Whether gRPC access is now enabled
+  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.
 }
 
 /*

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1137,6 +1137,7 @@ message FirmwareObjectHistoryRecord {
 message ConfigureScaleUpFabricManagerRequest {
   NodeInfo node = 2; // Target switch identity and direct connection information
   string topology_type = 3; // Topology to be set for ScaleUpFabric
+  optional string domain = 7; // Optional site selector; defaults to --default-switch-tls-domain when unset.
 }
 
 // ConfigureScaleUpFabricManagerResponse reports the ScaleUpFabricManager  configuration result.
@@ -1146,7 +1147,6 @@ message ConfigureScaleUpFabricManagerResponse {
   string topology_used = 4; // multi-node scaleup topology that was applied
   bool scale_up_fabric_state_enabled = 5; // Whether the ScaleUpFabricState State is now enabled
   bool grpc_enabled = 6; // Whether gRPC access is now enabled
-  optional string domain = 7; // Optional site selector; defaults to --default-switch-tls-domain when unset.
 }
 
 /*

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1137,7 +1137,7 @@ message FirmwareObjectHistoryRecord {
 message ConfigureScaleUpFabricManagerRequest {
   NodeInfo node = 2; // Target switch identity and direct connection information
   string topology_type = 3; // Topology to be set for ScaleUpFabric
-  optional string domain = 7; // Optional site selector; defaults to --default-switch-tls-domain when unset.
+  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.
 }
 
 // ConfigureScaleUpFabricManagerResponse reports the ScaleUpFabricManager  configuration result.
@@ -1205,9 +1205,7 @@ message ConfigureSwitchCertificateRequest {
   NodeSet nodes = 1; // Switch nodes to update
   repeated SwitchService services = 2; // Switch services to protect with the installed mTLS certificates
   bool test_hello = 3; // Test Hello Connection over mTLS
-  optional string domain = 4; // Required domain/site selector applied to all nodes in this request.
-  // RMS resolves switch certificate material under <switch_cert_root>/<domain>
-  // and TestHello client material under <client_tls_root>/<domain>.
+  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.  
 }
 
 // ConfigureSwitchCertificateResponse reports switch certificate configuration job creation results.

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1146,7 +1146,7 @@ message ConfigureScaleUpFabricManagerResponse {
   string topology_used = 4; // multi-node scaleup topology that was applied
   bool scale_up_fabric_state_enabled = 5; // Whether the ScaleUpFabricState State is now enabled
   bool grpc_enabled = 6; // Whether gRPC access is now enabled
-  optional string domain = 4; // Optional site selector; defaults to --default-switch-tls-domain when unset.
+  optional string domain = 7; // Optional site selector; defaults to --default-switch-tls-domain when unset.
 }
 
 /*

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1204,7 +1204,7 @@ message ConfigureSwitchCertificateRequest {
   NodeSet nodes = 1; // Switch nodes to update
   repeated SwitchService services = 2; // Switch services to protect with the installed mTLS certificates
   bool test_hello = 3; // Test Hello Connection over mTLS
-  string domain = 4; // Required domain/site selector applied to all nodes in this request.
+  optional string domain = 4; // Required domain/site selector applied to all nodes in this request.
   // RMS resolves switch certificate material under <switch_cert_root>/<domain>
   // and TestHello client material under <client_tls_root>/<domain>.
 }


### PR DESCRIPTION
Add optional `domain` to ConfigureScaleUpFabricManagerRequest and
ConfigureSwitchCertificateRequest so callers can choose per-site TLS
material. When unset, RMS falls back to `--default-switch-domain`.

