### PR TITLE
Add host name to Endpoint

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -153,6 +153,7 @@ message Credentials {
 message NetworkInterface {
   string ip_address = 1; // IPv4 or IPv6 textual address
   string mac_address = 2; // Text MAC address
+  string host_name = 3; // Host name is required for TLS connection
 }
 
 // Endpoint describes one network endpoint and its credentials.

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -153,7 +153,7 @@ message Credentials {
 message NetworkInterface {
   string ip_address = 1; // IPv4 or IPv6 textual address
   string mac_address = 2; // Text MAC address
-  string host_name = 3; // Host name is required for TLS connection
+  optional string host_name = 3; // Host name is required for TLS connection
 }
 
 // Endpoint describes one network endpoint and its credentials.


### PR DESCRIPTION
Add hostname to node management Endpoint.

Store an optional DNS hostname alongside IP, MAC, and port so mTLS and NVUE connectivity can use the switch host name for SNI while still connecting to the management IP.