### PR TITLE
feat(api): add SDN factory-default reset async RPCs

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -598,6 +598,15 @@ service RackManager {
   rpc ConfigureScaleUpFabricManager(ConfigureScaleUpFabricManagerRequest) returns (ConfigureScaleUpFabricManagerResponse) {}
 
   /*
+   * BatchResetSwitchSdnFactoryDefault submits asynchronous SDN factory-default resets.
+   * All switches in the request use the same domain for switch mTLS material.
+   * Returns parent and per-node child job IDs. Use GetJobStatus to track progress.
+   * The reset is idempotent; callers can retry after transport or service failure.
+   * Note: post hard reset, operator has to trigger the nmxconfigure rack state machine substate.
+   */
+  rpc BatchResetSwitchSdnFactoryDefault(BatchResetSwitchSdnFactoryDefaultRequest) returns (BatchResetSwitchSdnFactoryDefaultResponse) {}
+
+  /*
    * BatchSetScaleUpFabricState synchronously sets ScaleUpFabric state and saves
    * config across all supplied switches.
    */
@@ -1221,6 +1230,24 @@ message ConfigureScaleUpFabricManagerResponse {
   string topology_used = 4; // multi-node scaleup topology that was applied
   bool scale_up_fabric_state_enabled = 5; // Whether the ScaleUpFabricState State is now enabled
   bool grpc_enabled = 6; // Whether gRPC access is now enabled
+}
+
+// BatchResetSwitchSdnFactoryDefaultRequest submits SDN factory-default resets for caller-supplied switches.
+message BatchResetSwitchSdnFactoryDefaultRequest {
+  NodeSet nodes = 1; // Target switch identities and direct connection information
+  optional string domain = 2; // Optional NVL domain for the target switch group; defaults to configured switch domain when unset
+}
+
+// BatchResetSwitchSdnFactoryDefaultResponse reports asynchronous reset submission status.
+message BatchResetSwitchSdnFactoryDefaultResponse {
+  NodeBatchResponse response = 1; // response.job_id is the parent job ID for GetJobStatus
+  repeated SwitchSdnFactoryDefaultResetJobInfo jobs = 2; // Per-node child jobs for GetJobStatus
+}
+
+// SwitchSdnFactoryDefaultResetJobInfo identifies a per-node SDN reset job.
+message SwitchSdnFactoryDefaultResetJobInfo {
+  string node_id = 1; // Target node ID
+  string job_id = 2; // Child job ID for this target switch
 }
 
 /*

--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -1241,13 +1241,6 @@ message BatchResetSwitchSdnFactoryDefaultRequest {
 // BatchResetSwitchSdnFactoryDefaultResponse reports asynchronous reset submission status.
 message BatchResetSwitchSdnFactoryDefaultResponse {
   NodeBatchResponse response = 1; // response.job_id is the parent job ID for GetJobStatus
-  repeated SwitchSdnFactoryDefaultResetJobInfo jobs = 2; // Per-node child jobs for GetJobStatus
-}
-
-// SwitchSdnFactoryDefaultResetJobInfo identifies a per-node SDN reset job.
-message SwitchSdnFactoryDefaultResetJobInfo {
-  string node_id = 1; // Target node ID
-  string job_id = 2; // Child job ID for this target switch
 }
 
 /*

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -301,6 +301,11 @@ pub trait RmsApi: Send + Sync + 'static {
         cmd: rms::ConfigureScaleUpFabricManagerRequest,
     ) -> Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>;
 
+    async fn batch_reset_switch_sdn_factory_default(
+        &self,
+        cmd: rms::BatchResetSwitchSdnFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchSdnFactoryDefaultResponse, RackManagerError>;
+
     async fn batch_set_scale_up_fabric_state(
         &self,
         cmd: rms::BatchSetScaleUpFabricStateRequest,
@@ -357,6 +362,11 @@ pub trait RmsApi: Send + Sync + 'static {
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
     ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError>;
+
+    async fn get_job_status(
+        &self,
+        cmd: rms::GetJobStatusRequest,
+    ) -> Result<rms::GetJobStatusResponse, RackManagerError>;
 }
 
 #[async_trait::async_trait]
@@ -602,6 +612,16 @@ impl RmsApi for RackManagerApi {
         Ok(self.client.configure_scale_up_fabric_manager(cmd).await?)
     }
 
+    async fn batch_reset_switch_sdn_factory_default(
+        &self,
+        cmd: rms::BatchResetSwitchSdnFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchSdnFactoryDefaultResponse, RackManagerError> {
+        Ok(self
+            .client
+            .batch_reset_switch_sdn_factory_default(cmd)
+            .await?)
+    }
+
     async fn batch_set_scale_up_fabric_state(
         &self,
         cmd: rms::BatchSetScaleUpFabricStateRequest,
@@ -690,6 +710,13 @@ impl RmsApi for RackManagerApi {
         cmd: rms::GetFirmwareJobStatusRequest,
     ) -> Result<rms::GetFirmwareJobStatusResponse, RackManagerError> {
         Ok(self.client.get_firmware_job_status(cmd).await?)
+    }
+
+    async fn get_job_status(
+        &self,
+        cmd: rms::GetJobStatusRequest,
+    ) -> Result<rms::GetJobStatusResponse, RackManagerError> {
+        Ok(self.client.get_job_status(cmd).await?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ mod tests {
         assert_serde::<rms::BatchSetScaleUpFabricStateResponse>();
         assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultRequest>();
         assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultResponse>();
-        assert_serde::<rms::SwitchSdnFactoryDefaultResetJobInfo>();
         assert_serde::<rms::JobStatus>();
         assert_serde::<rms::GetJobStatusRequest>();
         assert_serde::<rms::GetJobStatusResponse>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,12 @@ mod tests {
         assert_serde::<rms::SetPowerStateResponse>();
         assert_serde::<rms::BatchSetScaleUpFabricStateRequest>();
         assert_serde::<rms::BatchSetScaleUpFabricStateResponse>();
+        assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultRequest>();
+        assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultResponse>();
+        assert_serde::<rms::SwitchSdnFactoryDefaultResetJobInfo>();
+        assert_serde::<rms::JobStatus>();
+        assert_serde::<rms::GetJobStatusRequest>();
+        assert_serde::<rms::GetJobStatusResponse>();
         assert_serde::<rms::ConfigureSwitchCertificateRequest>();
         assert_serde::<rms::ConfigureSwitchCertificateResponse>();
         assert_serde::<rms::ConfigureSwitchCertificateJobInfo>();


### PR DESCRIPTION
SDN factory-default reset async RPCs:

- Add `BatchResetSwitchSdnFactoryDefault` RPC.
- Add request/response proto messages for SDN reset jobs.
- Expose the new RPCs through `RmsApi` and `RackManagerApi`.

### Notes

- SDN factory reset is destructive, so it is added as a separate RPC.
- SDN factory reset can take 10+ seconds to complete on a switch; the RPC is async so callers are not coupled to a long-running request.
- This change is additive and has no breaking changes.