### PR TITLE
feat(rpc)!: convert UpdateSwitchSystemPassword to async

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -71,6 +71,7 @@ enum JobError {
   JOB_ERROR_SERVER_ERROR = 12; // Server returned an error response
   JOB_ERROR_TIMEOUT = 13; // Timed out waiting for an operation to complete
   JOB_ERROR_INVALID_RESPONSE = 14; // Received invalid or malformed response
+  JOB_ERROR_UNAUTHENTICATED = 15; // Provided credentials could not authenticate
   
   // Update specific
 
@@ -664,9 +665,11 @@ service RackManager {
   rpc GetSwitchSystemImageJobStatus(GetSwitchSystemImageJobStatusRequest) returns (GetSwitchSystemImageJobStatusResponse) {}
 
   /*
-   * UpdateSwitchSystemPassword updates the OS-level password for a specific user
-   * on a caller-supplied list of switch nodes. Credentials are resolved from
-   * the node's stored inventory data.
+   * UpdateSwitchSystemPassword initiates asynchronous OS-level password updates
+   * for a specific user on a caller-supplied list of switch nodes. The caller
+   * supplies both the current password and desired next password so retries can
+   * resume after a partial failure. Returns a parent job ID in response.job_id;
+   * use GetJobStatus to track progress.
    */
   rpc UpdateSwitchSystemPassword(UpdateSwitchSystemPasswordRequest) returns (UpdateSwitchSystemPasswordResponse) {}
 
@@ -1411,16 +1414,16 @@ message PollSwitchFirmwareJobStatusResponse {
  * SWITCH PASSWORD CONTROL MESSAGES
  ******************************************************************************/
 
-// UpdateSwitchSystemPasswordRequest updates the OS-level password for a user on a set of switch nodes.
+// UpdateSwitchSystemPasswordRequest starts an OS-level password update for a user on a set of switch nodes.
 message UpdateSwitchSystemPasswordRequest {
   NodeSet nodes = 2; // Switch nodes to update
   string username = 3; // Target OS username whose password will be changed (mandatory)
   string password = 4; // New password to set for the user (mandatory)
 }
 
-// UpdateSwitchSystemPasswordResponse reports the per-node results of a synchronous password update.
+// UpdateSwitchSystemPasswordResponse reports switch password update job creation results.
 message UpdateSwitchSystemPasswordResponse {
-  NodeBatchResponse response = 1;
+  NodeBatchResponse response = 1; // response.job_id is the parent job ID for GetJobStatus
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This PR changes `UpdateSwitchSystemPassword` from a synchronous switch password update RPC into an asynchronous job-based RPC.

The request shape stays aligned:

- `nodes = 2`
- `username = 3`
- `password = 4`

`username` remains the target NVOS user whose password will be changed. `password` remains the desired final password for that user.

RMS authenticates to the switch using the switch `host_endpoint.credentials`. The request `username` is intentionally separate from the endpoint auth username, so callers can update either the endpoint user or a different OS/NVOS user.

Retryability comes from replaying the desired final state. RMS can reapply the same `username -> password` update, accept NVUE no-config-diff as idempotent success, and continue persisting the applied config. When the target user is also the host endpoint auth user, RMS can use the requested `password` as candidate credentials after the old endpoint password stops authenticating, which lets it resume after a partial password-change failure.

The response returns the parent job ID through `response.job_id`; callers should use `GetJobStatus(response.job_id)` to track progress and final per-node results.

### Breaking Change

This is a breaking API behavior change, even though the request wire format for `UpdateSwitchSystemPasswordRequest` remains compatible.

- The RPC response no longer means "password update completed", but "password update jobs were accepted."
- Callers must poll `GetJobStatus(response.job_id)` for completion and final per-node results.

This is low impact because NICo does not use this RPC yet.

### Other API Changes

- Added `JOB_ERROR_UNAUTHENTICATED` so RMS can report credential-authentication failures through generic job status.