### PR TITLE
feat(node): add node-descriptor for hardware type-specific support

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -186,6 +186,11 @@ message Endpoint {
   Credentials credentials = 3;
 }
 
+// NodeDescriptor carries flexible hardware identity attributes for RMS dispatch.
+message NodeDescriptor {
+  map<string, string> attributes = 1; // RMS dispatch currently accepts role, vendor, and product_family
+}
+
 /*******************************************************************************
  * SHARED DATA TYPES
  ******************************************************************************/
@@ -194,9 +199,10 @@ message Endpoint {
 message NodeInfo {
   string node_id = 1; // Unique identifier for the node within the rack
   string rack_id = 2; // Identifier of the rack containing this node
-  optional NodeType type = 3; // Hardware-specific node type
+  optional NodeType type = 3; // Hardware-specific node type; non-UNSPECIFIED values override node_descriptor
   optional Endpoint bmc_endpoint = 4; // BMC connection info and credentials
   optional Endpoint host_endpoint = 5; // Host connection info and credentials
+  optional NodeDescriptor node_descriptor = 6; // Flexible node identity used when type is missing or NODE_TYPE_UNSPECIFIED
 }
 
 // NodeSet represents a collection of nodes, reusable wherever a node list is needed.
@@ -226,6 +232,7 @@ message NodeInventoryInfo {
   string rack_id = 9; // Identifier of the rack containing this node
   repeated string host_mac_addresses = 10; // Vector of MAC addresses of the node's Host interfaces
   repeated string host_ip_addresses = 11; // Vector of IP addresses of the node's Host interfaces
+  optional NodeDescriptor node_descriptor = 12; // Flexible node identity returned for descriptor-aware clients
 }
 
 // NodeDeviceInfo represents normalized device metadata for a node.
@@ -848,7 +855,8 @@ message GetNodeDeviceInfoResponse {
 // ListNodeDeviceInfoByNodeTypeRequest retrieves device metadata for all nodes of a type in a rack.
 message ListNodeDeviceInfoByNodeTypeRequest {
   string rack_id = 2; // Target rack identifier
-  NodeType node_type = 3; // Type of nodes to query
+  NodeType node_type = 3; // Type of nodes to query; non-UNSPECIFIED values override node_descriptor
+  optional NodeDescriptor node_descriptor = 4; // Flexible node identity used when node_type is NODE_TYPE_UNSPECIFIED
 }
 
 // ListNodeDeviceInfoByNodeTypeResponse returns device metadata for all matching nodes in a rack.
@@ -899,9 +907,21 @@ message FirmwareTargetList {
   repeated FirmwareTarget targets = 1;
 }
 
-// FirmwareObjectComponentFilter wraps component names for one NodeType key.
+// NodeDescriptorFirmwareTargetList pairs a flexible node identity with firmware targets.
+message NodeDescriptorFirmwareTargetList {
+  NodeDescriptor node_descriptor = 1;
+  FirmwareTargetList firmware_targets = 2;
+}
+
+// FirmwareObjectComponentFilter wraps component names for one node selector.
 message FirmwareObjectComponentFilter {
   repeated string components = 1; // Optional component filter for one node type
+}
+
+// NodeDescriptorFirmwareObjectComponentFilter pairs a flexible node identity with a component filter.
+message NodeDescriptorFirmwareObjectComponentFilter {
+  NodeDescriptor node_descriptor = 1;
+  FirmwareObjectComponentFilter component_filter = 2;
 }
 
 // UpdateFirmwareRequest initiates a firmware update on a node.
@@ -929,13 +949,14 @@ message UpdateFirmwareResponse {
 // Supports single target (filename + target fields) or multiple targets (firmware_targets list).
 // If firmware_targets is non-empty, it takes precedence over the single filename/target fields.
 message BatchUpdateFirmwareByNodeTypeRequest {
-  NodeType node_type = 2; // Type of nodes to update
+  NodeType node_type = 2; // Type of nodes to update; non-UNSPECIFIED values override node_descriptor
   string filename = 3; // Single firmware filename (used when firmware_targets is empty)
   string target = 4; // Single Redfish target URI (used when firmware_targets is empty)
   string rack_id = 5; // Target rack identifier
   repeated FirmwareTarget firmware_targets = 6; // Multiple (target, filename) pairs for batch component updates
   bool activate = 7; // Whether to activate firmware after all targets are flashed
   bool force_update = 8; // Force the BMC to accept the firmware even if it's a downgrade
+  optional NodeDescriptor node_descriptor = 9; // Flexible node identity used when node_type is NODE_TYPE_UNSPECIFIED
 }
 
 // NodeFirmwareJobInfo pairs a node ID with its async firmware job ID.
@@ -958,6 +979,7 @@ message BatchUpdateFirmwareRequest {
   map<int32, FirmwareTargetList> firmware_targets = 3; // Firmware targets keyed by NodeType enum value
   bool activate = 4; // Whether to activate firmware after installation
   bool force_update = 5; // Force the BMC to accept the firmware even if it's a downgrade
+  repeated NodeDescriptorFirmwareTargetList node_descriptor_firmware_targets = 6; // Firmware targets keyed by flexible node identity
 }
 
 // BatchUpdateFirmwareResponse reports firmware update results.
@@ -1021,6 +1043,7 @@ message FirmwareObjectDeviceComponents {
   NodeType node_type = 1;
   string device_type = 2; // SOT device type label, e.g. "Compute Node", "Switch Tray", "Power Shelf"
   repeated FirmwareObjectComponent components = 3;
+  optional NodeDescriptor node_descriptor = 4; // Flexible node identity for descriptor-aware clients
 }
 
 // FirmwareObjectComponent describes one normalized component clients can request.
@@ -1115,6 +1138,7 @@ message ApplyStoredFirmwareObjectRequest {
   // Component filters keyed by NodeType. If non-empty, only listed node types are updated.
   // A listed node type with an empty components list means all components for that node type.
   map<int32, FirmwareObjectComponentFilter> component_filters = 9;
+  repeated NodeDescriptorFirmwareObjectComponentFilter node_descriptor_component_filters = 10; // Component filters keyed by flexible node identity
 }
 
 message ApplyStoredFirmwareObjectResponse {
@@ -1134,6 +1158,7 @@ message ApplyFirmwareObjectRequest {
   // Component filters keyed by NodeType. If non-empty, only listed node types are updated.
   // A listed node type with an empty components list means all components for that node type.
   map<int32, FirmwareObjectComponentFilter> component_filters = 9;
+  repeated NodeDescriptorFirmwareObjectComponentFilter node_descriptor_component_filters = 10; // Component filters keyed by flexible node identity
 }
 
 message ApplyFirmwareObjectResponse {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,9 @@ mod tests {
         // Plain message
         assert_serde::<rms::Credentials>();
         assert_serde::<rms::ComponentInventoryInfo>();
+        assert_serde::<rms::NodeDescriptor>();
+        assert_serde::<rms::NodeDescriptorFirmwareTargetList>();
+        assert_serde::<rms::NodeDescriptorFirmwareObjectComponentFilter>();
 
         // Oneof enum - the case that previously required special handling in build.rs
         assert_serde::<rms::credentials::Auth>();


### PR DESCRIPTION
Add `NodeDescriptor` as a flexible alternative to `NodeType` for RMS hardware dispatch.

### Changes

- Add `NodeDescriptor` to node information and inventory messages.
- Add descriptor selectors to by-type device and firmware requests.
- Add descriptor-keyed firmware target and component filter messages.
- Preserve `NodeType` as an override when it is non-`UNSPECIFIED`.

### Compatibility

This is an additive migration. Existing enum-based clients continue using `NodeType`. Descriptor-aware clients can use an unspecified or absent node type and provide `node_descriptor`.

### Motivation

Using descriptors decouples client releases from additions to the `NodeType` enum. RMS can translate descriptors to its internal node types while clients describe supported hardware without exhaustive enum matching.