### PR TITLE
feat(switch): add RPC to support NVOS factory reset

### DIFF
--- a/proto/rack_manager.proto
+++ b/proto/rack_manager.proto
@@ -573,6 +573,20 @@ service RackManager {
    */
   rpc PushSwitchFirmware(PushSwitchFirmwareRequest) returns (PushSwitchFirmwareResponse) {}
 
+  /*
+   * BatchResetSwitchFactoryDefault submits asynchronous NVOS factory resets.
+   * All switches in the request use the same domain for switch mTLS material.
+   * Returns a parent job ID. Use GetJobStatus with child job states to track per-node progress.
+   * Unlike the SDN reset, this wipes NVOS configuration back to factory defaults.
+   *
+   * A per-node job completes once the switch has rebooted after the reset and is
+   * reachable again via the default login; the factory default password is
+   * preserved, not rotated. If the supplied switch credentials do not work, RMS
+   * falls back to the factory default password to perform the reset, without
+   * assuming a switch was already reset just because the default login works.
+   */
+  rpc BatchResetSwitchFactoryDefault(BatchResetSwitchFactoryDefaultRequest) returns (BatchResetSwitchFactoryDefaultResponse) {}
+
   /*---------------------------------------------------------------------------
    * Scale Up switch control RPCs
    *-------------------------------------------------------------------------*/
@@ -1458,6 +1472,17 @@ message PushSwitchFirmwareResponse {
   ReturnCode status = 2; // RETURN_CODE_SUCCESS if pushed, RETURN_CODE_FAILURE otherwise
   string result_json = 3; // JSON object containing push result
   string error_message = 4; // Error details if push failed
+}
+
+// BatchResetSwitchFactoryDefaultRequest submits NVOS factory-default resets for caller-supplied switches.
+message BatchResetSwitchFactoryDefaultRequest {
+  NodeSet nodes = 1; // Target switch identities and direct connection information
+  optional string domain = 2; // Optional domain for the target switch group; defaults to configured switch domain when unset
+}
+
+// BatchResetSwitchFactoryDefaultResponse reports asynchronous reset submission status.
+message BatchResetSwitchFactoryDefaultResponse {
+  NodeBatchResponse response = 1; // response.job_id is the parent job ID for GetJobStatus
 }
 
 /*******************************************************************************

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -307,6 +307,19 @@ pub trait RmsApi: Send + Sync + 'static {
         cmd: rms::PushSwitchFirmwareRequest,
     ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError>;
 
+    /// Submits asynchronous NVOS factory-default resets for the given switches.
+    ///
+    /// Implementors may omit this method; the default returns `Unimplemented`.
+    async fn batch_reset_switch_factory_default(
+        &self,
+        _cmd: rms::BatchResetSwitchFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchFactoryDefaultResponse, RackManagerError> {
+        Err(tonic::Status::unimplemented(
+            "BatchResetSwitchFactoryDefault is not implemented by this RmsApi",
+        )
+        .into())
+    }
+
     /// Submits V2 scale-up fabric reconciliation configuration.
     ///
     /// Implementors may omit this method; the default returns `Unimplemented`.
@@ -630,6 +643,13 @@ impl RmsApi for RackManagerApi {
         cmd: rms::PushSwitchFirmwareRequest,
     ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
         Ok(self.client.push_switch_firmware(cmd).await?)
+    }
+
+    async fn batch_reset_switch_factory_default(
+        &self,
+        cmd: rms::BatchResetSwitchFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchFactoryDefaultResponse, RackManagerError> {
+        Ok(self.client.batch_reset_switch_factory_default(cmd).await?)
     }
 
     async fn configure_scale_up_fabric_manager_v2(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,8 @@ mod tests {
         assert_serde::<rms::BatchSetScaleUpFabricStateResponse>();
         assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultRequest>();
         assert_serde::<rms::BatchResetSwitchSdnFactoryDefaultResponse>();
+        assert_serde::<rms::BatchResetSwitchFactoryDefaultRequest>();
+        assert_serde::<rms::BatchResetSwitchFactoryDefaultResponse>();
         assert_serde::<rms::JobStatus>();
         assert_serde::<rms::GetJobStatusRequest>();
         assert_serde::<rms::GetJobStatusResponse>();


### PR DESCRIPTION
Add `BatchResetSwitchFactoryDefault` RPC along with its request/response messages and the corresponding `RmsApi` client-trait method.

**Target Behavior**

- Returns a parent job ID; callers poll `GetJobStatus` with the child job states for per-node progress.
- A per-node job completes once the switch has rebooted after the reset and is reachable again via the default login.
- The factory default password is not rotated.
- If the supplied switch credentials don't work, RMS falls back to the factory default password to perform the reset without assuming a switch was already reset.
- All switches in a request share the same domain for switch mTLS material (`domain` defaults to the configured switch domain when unset).

